### PR TITLE
Enable optional schema override

### DIFF
--- a/src/runtime/composables/useSupabaseClient.ts
+++ b/src/runtime/composables/useSupabaseClient.ts
@@ -2,11 +2,14 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import { useSupabaseToken } from './useSupabaseToken'
 import { useRuntimeConfig, useNuxtApp } from '#imports'
 
-export const useSupabaseClient = (): SupabaseClient => {
+export const useSupabaseClient = (schema?: string): SupabaseClient => {
   const nuxtApp = useNuxtApp()
   const token = useSupabaseToken()
   const { supabase: { url, key, client: options } } = useRuntimeConfig().public
-
+  
+  // override the default schema if optional parameter has been set
+  options.schema = schema || 'public';
+  
   // No need to recreate client if exists
   if (!nuxtApp._supabaseClient) {
     nuxtApp._supabaseClient = createClient(url, key, options)


### PR DESCRIPTION
It would be nice to make it possible to override the default schema. It's a non-breaking-change.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
By giving the `useSupabaseClient` this optional parameter, the schema-selection is not limited to `public`.
<!--- Why is this change required? What problem does it solve? -->
This enables very easy schema selection which is useful for more complex databases.
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

The change seems too minor to test.
