### PR TITLE
fix: remove websocket transpile during build

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -158,12 +158,22 @@ export default defineNuxtModule<ModuleOptions>({
       options.references.push({ path: resolve(nuxt.options.buildDir, 'types/supabase.d.ts') })
     })
 
-    // Optimize cross-fetch & websocket
+    // Optimize cross-fetch
     extendViteConfig((config) => {
       config.optimizeDeps = config.optimizeDeps || {}
       config.optimizeDeps.include = config.optimizeDeps.include || []
       config.optimizeDeps.include.push('cross-fetch')
-      config.optimizeDeps.include.push('websocket')
     })
+
+    if (nuxt.options.dev) {
+      extendViteConfig((config) => {
+        config.optimizeDeps = config.optimizeDeps || {}
+        config.optimizeDeps.include = config.optimizeDeps.include || []
+        config.optimizeDeps.include.push('websocket')
+      })
+      // Transpile websocket only for non dev environments
+    } else if (!['cloudflare'].includes(process.env.NITRO_PRESET)) {
+      nuxt.options.build.transpile.push('websocket')
+    }
   }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -158,23 +158,12 @@ export default defineNuxtModule<ModuleOptions>({
       options.references.push({ path: resolve(nuxt.options.buildDir, 'types/supabase.d.ts') })
     })
 
-    // Optimize cross-fetch
+    // Optimize cross-fetch & websocket
     extendViteConfig((config) => {
       config.optimizeDeps = config.optimizeDeps || {}
       config.optimizeDeps.include = config.optimizeDeps.include || []
       config.optimizeDeps.include.push('cross-fetch')
+      config.optimizeDeps.include.push('websocket')
     })
-
-    // Optimize websocket only at dev time
-    if (nuxt.options.dev) {
-      extendViteConfig((config) => {
-        config.optimizeDeps = config.optimizeDeps || {}
-        config.optimizeDeps.include = config.optimizeDeps.include || []
-        config.optimizeDeps.include.push('websocket')
-      })
-      // Transpile websocket only for non dev environments
-    } else {
-      nuxt.options.build.transpile.push('websocket')
-    }
   }
 })


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Fixes #46 

Using `build.transpile` for `websocket` package makes any app using this module broken on Cloudflare Workers (unpublishable).

Therefore, we just keep the `viteConfig.optimizeDeps` so it correctly works in development, and doing it as well for builds has 0 bundle cost, so this change should be more than ideal to fix the issue !

**Update**: See https://github.com/nuxt-modules/supabase/pull/84#issuecomment-1271374397