### PR TITLE
fix: do not apply token if not exists

### DIFF
--- a/src/runtime/server/services/serverSupabaseClient.ts
+++ b/src/runtime/server/services/serverSupabaseClient.ts
@@ -12,7 +12,7 @@ export const serverSupabaseClient = (event: H3Event): SupabaseClient => {
     const token = getCookie(event, `${cookieOptions.name}-access-token`)
 
     // Set auth header to make use of RLS
-    const options = defu(clientOptions, { global: { headers: { Authorization: `Bearer ${token}` } } })
+    const options = token ? defu(clientOptions, { global: { headers: { Authorization: `Bearer ${token}` } } }) : clientOptions
 
     const supabaseClient = createClient(url, key, options)
 


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

When using supabase as first request via SSR, or API call when no user is logged in, no `token` exists. Content can still be accessible when RLS is set to public.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
