### PR TITLE
feat(composables): add useSubabaseAuthClient

### DIFF
--- a/docs/content/3.usage/1.composables/1.use-supabase-auth-client.md
+++ b/docs/content/3.usage/1.composables/1.use-supabase-auth-client.md
@@ -5,9 +5,13 @@ description: null
 
 [Auto-import](https://v3.nuxtjs.org/docs/directory-structure/composables) your client inside your vue files.
 
-This composable is using [supabase-js](https://github.com/supabase/supabase-js/) under the hood, it gives acces to the [Supabase client](https://supabase.com/docs/reference/javascript/supabase-client) in order to handle authentification actions, all methods are available on [Supabase Auth](https://supabase.com/docs/reference/javascript/next/auth-signinwithpassword) Documentation.
+This composable is using [supabase-js](https://github.com/supabase/supabase-js/) under the hood, it gives acces to the [Supabase client](https://supabase.com/docs/reference/javascript/supabase-client) in order to handle authentification actions, all methods are available on [Supabase Auth](https://supabase.com/docs/reference/javascript/auth-signup) Documentation.
 
 > The client is initialized with the `SUPABASE_KEY` you must have in your `.env` file.
+
+::alert
+This client is dedicated to authentification purpose only. It won't be recreate if your token expires, it is used in the client plugin to listen to `onAuthStateChange` events. If you want to fetch data from the db, please use the [useSupabaseClient](/usage/composables/use-supabase-client) instead.
+::
 
 ## SignIn
 

--- a/docs/content/3.usage/1.composables/1.use-supabase-auth-client.md
+++ b/docs/content/3.usage/1.composables/1.use-supabase-auth-client.md
@@ -1,0 +1,57 @@
+---
+title: useSupabaseAuthClient
+description: null
+---
+
+[Auto-import](https://v3.nuxtjs.org/docs/directory-structure/composables) your client inside your vue files.
+
+This composable is using [supabase-js](https://github.com/supabase/supabase-js/) under the hood, it gives acces to the [Supabase client](https://supabase.com/docs/reference/javascript/supabase-client) in order to handle authentification actions, all methods are available on [Supabase Auth](https://supabase.com/docs/reference/javascript/next/auth-signinwithpassword) Documentation.
+
+> The client is initialized with the `SUPABASE_KEY` you must have in your `.env` file.
+
+## SignIn
+
+Here is an example of the login using the `signInWithOAuth` method with [third-party providers](https://supabase.com/docs/reference/javascript/next/auth-signinwithoauth).
+
+```vue [pages/login.vue]
+<script setup lang="ts">
+const user = useSupabaseUser()
+const client = useSupabaseAuthClient()
+const router = useRouter()
+
+// Login method using providers
+const login = async (provider: 'github' | 'google' | 'gitlab' | 'bitbucket') => {
+  const { error } = await client.auth.signInWithOAuth({ provider })
+
+  if (error) {
+    return alert('Something went wrong !')
+  }
+
+  router.push('/dashboard')
+}
+</script>
+
+<template>
+  <button @click="login('github')">Login with GitHub</button>
+</template>
+```
+
+::alert
+Thanks to the [Nuxt plugin](https://v3.nuxtjs.org/docs/directory-structure/plugins), we are listening to the [onAuthStateChange](https://supabase.com/docs/reference/javascript/auth-onauthstatechange) listener in order to update the user value according to the received event. We also keep the session consistency between client and server side.
+::
+
+> Take a look at the [auth middleware](/usage/composables/use-supabase-user#auth-middleware) section to learn how to leverage Nuxt middleware to protect your routes for unauthenticated users.
+
+## SignOut
+
+Check [Supabase Documentation](https://supabase.com/docs/reference/javascript/next/auth-signout) for further details.
+
+```vue
+<template>
+  <button @click="client.auth.signOut()">Logout</button>
+</template>
+
+<script>
+const client = useSupabaseAuthClient()
+</script>
+```

--- a/docs/content/3.usage/1.composables/1.use-supabase-client.md
+++ b/docs/content/3.usage/1.composables/1.use-supabase-client.md
@@ -13,63 +13,6 @@ This composable is using [supabase-js](https://github.com/supabase/supabase-js/)
 
 > The client is initialized with the `SUPABASE_KEY` you must have in your `.env` file. It establishes the connection with the database and make use of user JWT to apply [RLS Policies](https://supabase.com/docs/learn/auth-deep-dive/auth-row-level-security) implemented in Supabase. If you want to bypass policies, you can use the [serverSupabaseServiceRole](/usage/services/server-supabase-service-role).
 
-```vue [pages/index.vue]
-<script setup>
-const client = useSupabaseClient()
-
-// Example: client.from('libraries').eq('name', 'Vue').single()
-</script>
-```
-
-## SignIn
-
-All authentification methods are available on [Supabase Auth](https://supabase.com/docs/reference/javascript/next/auth-signinwithpassword) Documentation.
-
-Here is an example of the login using the `signInWithOAuth` method with [third-party providers](https://supabase.com/docs/reference/javascript/next/auth-signinwithoauth).
-
-```vue [pages/login.vue]
-<script setup lang="ts">
-const user = useSupabaseUser()
-const client = useSupabaseClient()
-const router = useRouter()
-
-// Login method using providers
-const login = async (provider: 'github' | 'google' | 'gitlab' | 'bitbucket') => {
-  const { error } = await client.auth.signInWithOAuth({ provider })
-
-  if (error) {
-    return alert('Something went wrong !')
-  }
-
-  router.push('/dashboard')
-}
-</script>
-
-<template>
-  <button @click="login('github')">Login with GitHub</button>
-</template>
-```
-
-::alert
-Thanks to the [Nuxt plugin](https://v3.nuxtjs.org/docs/directory-structure/plugins), we are listening to the [onAuthStateChange](https://supabase.com/docs/reference/javascript/auth-onauthstatechange) listener in order to update the user value according to the received event. We also keep the session consistency between client and server side.
-::
-
-> Take a look at the [auth middleware](/usage/composables/use-supabase-user#auth-middleware) section to learn how to leverage Nuxt middleware to protect your routes for unauthenticated users.
-
-## SignOut
-
-Check [Supabase Documentation](https://supabase.com/docs/reference/javascript/next/auth-signout) for further details.
-
-```vue
-<template>
-  <button @click="client.auth.signOut()">Logout</button>
-</template>
-
-<script>
-const client = useSupabaseClient()
-</script>
-```
-
 ## Database Request
 
 Please check [Supabase](https://supabase.com/docs/reference/javascript/select) documentation to fully use the power of Supabase client.

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -14,7 +14,7 @@
 
 <script setup lang="ts">
 const user = useSupabaseUser()
-const client = useSupabaseClient()
+const client = useSupabaseAuthClient()
 
 const logout = async () => {
   await client.auth.signOut()

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -6,7 +6,7 @@
 
 <script setup lang="ts">
 const user = useSupabaseUser()
-const client = useSupabaseClient()
+const client = useSupabaseAuthClient()
 
 watchEffect(() => {
   if (user.value) {

--- a/playground/pages/me.vue
+++ b/playground/pages/me.vue
@@ -22,7 +22,9 @@
 </template>
 
 <script setup lang="ts">
-const client = useSupabaseClient()
+import { Database } from '~~/types/database.types'
+
+const client = useSupabaseClient<Database>('me')
 const user = useSupabaseUser()
 const userFromServer = ref(null)
 const userFromComposable = ref(null)

--- a/playground/pages/me.vue
+++ b/playground/pages/me.vue
@@ -24,7 +24,7 @@
 <script setup lang="ts">
 import { Database } from '~~/types/database.types'
 
-const client = useSupabaseClient<Database>('me')
+const client = useSupabaseClient<Database>()
 const user = useSupabaseUser()
 const userFromServer = ref(null)
 const userFromComposable = ref(null)

--- a/playground/types/database.types.ts
+++ b/playground/types/database.types.ts
@@ -1,0 +1,75 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json }
+  | Json[]
+
+export interface Database {
+  public: {
+    Tables: {
+      pushupers: {
+        Row: {
+          id: number
+          created_at: string | null
+          email: string
+          firstname: string | null
+          lastname: string | null
+          avatar: string | null
+          user_id: string
+        }
+        Insert: {
+          id?: number
+          created_at?: string | null
+          email: string
+          firstname?: string | null
+          lastname?: string | null
+          avatar?: string | null
+          user_id: string
+        }
+        Update: {
+          id?: number
+          created_at?: string | null
+          email?: string
+          firstname?: string | null
+          lastname?: string | null
+          avatar?: string | null
+          user_id?: string
+        }
+      }
+      workouts: {
+        Row: {
+          id: number
+          created_at: string | null
+          date: string
+          user_id: string
+          repetitions: number
+        }
+        Insert: {
+          id?: number
+          created_at?: string | null
+          date: string
+          user_id: string
+          repetitions?: number
+        }
+        Update: {
+          id?: number
+          created_at?: string | null
+          date?: string
+          user_id?: string
+          repetitions?: number
+        }
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      [_ in never]: never
+    }
+  }
+}

--- a/src/runtime/composables/useSupabaseAuthClient.ts
+++ b/src/runtime/composables/useSupabaseAuthClient.ts
@@ -3,23 +3,20 @@ import { defu } from 'defu'
 import { useSupabaseToken } from './useSupabaseToken'
 import { useRuntimeConfig, useNuxtApp } from '#imports'
 
-export const useSupabaseClient = <T>(): SupabaseClient<T> => {
+export const useSupabaseAuthClient = <T>(): SupabaseClient<T> => {
   const nuxtApp = useNuxtApp()
   const token = useSupabaseToken()
   const Authorization = token.value ? `Bearer ${token.value}` : undefined
 
   const { supabase: { url, key, client: clientOptions } } = useRuntimeConfig().public
 
-  // Set auth header to make use of RLS
+  // Set auth header
   const options = Authorization ? defu(clientOptions, { global: { headers: { Authorization } } }) : clientOptions
 
-  // Recreate client if token has changed
-  const recreateClient = nuxtApp._supabaseClient?.headers.Authorization !== Authorization
-
   // No need to recreate client if exists
-  if (!nuxtApp._supabaseClient || recreateClient) {
-    nuxtApp._supabaseClient = createClient(url, key, options)
+  if (!nuxtApp._supabaseAuthClient) {
+    nuxtApp._supabaseAuthClient = createClient(url, key, options)
   }
 
-  return nuxtApp._supabaseClient
+  return nuxtApp._supabaseAuthClient
 }

--- a/src/runtime/plugins/supabase.client.ts
+++ b/src/runtime/plugins/supabase.client.ts
@@ -1,18 +1,18 @@
 import { AuthChangeEvent, Session } from '@supabase/supabase-js'
-import { useSupabaseClient } from '../composables/useSupabaseClient'
+import { useSupabaseAuthClient } from '../composables/useSupabaseAuthClient'
 import { useSupabaseUser } from '../composables/useSupabaseUser'
 import { useSupabaseToken } from '../composables/useSupabaseToken'
 import { defineNuxtPlugin } from '#imports'
 
 export default defineNuxtPlugin(async (nuxtApp) => {
   const user = useSupabaseUser()
-  const client = useSupabaseClient()
+  const authClient = useSupabaseAuthClient()
 
   // If user has not been set on server side (for instance in SPA), set it for client
   if (!user.value) {
     const token = useSupabaseToken()
     if (token.value) {
-      const { data: { user: supabaseUser }, error } = await client.auth.getUser(token.value)
+      const { data: { user: supabaseUser }, error } = await authClient.auth.getUser(token.value)
 
       if (error) {
         token.value = null
@@ -26,9 +26,9 @@ export default defineNuxtPlugin(async (nuxtApp) => {
   // Once Nuxt app is mounted
   nuxtApp.hooks.hook('app:mounted', () => {
     // Listen to Supabase auth changes
-    client.auth.onAuthStateChange(async (event: AuthChangeEvent, session: Session | null) => {
+    authClient.auth.onAuthStateChange(async (event: AuthChangeEvent, session: Session | null) => {
       await setServerSession(event, session)
-      const userResponse = session ? await client.auth.getUser() : null
+      const userResponse = session ? await authClient.auth.getUser() : null
       user.value = userResponse ? userResponse.data.user : null
     })
   })

--- a/src/runtime/plugins/supabase.server.ts
+++ b/src/runtime/plugins/supabase.server.ts
@@ -1,5 +1,5 @@
 import { useSupabaseUser } from '../composables/useSupabaseUser'
-import { useSupabaseClient } from '../composables/useSupabaseClient'
+import { useSupabaseAuthClient } from '../composables/useSupabaseAuthClient'
 import { useSupabaseToken } from '../composables/useSupabaseToken'
 import { redirectToLogin } from '../utils/redirect'
 import { defineNuxtPlugin, useRoute } from '#imports'
@@ -7,7 +7,7 @@ import { defineNuxtPlugin, useRoute } from '#imports'
 // Set subabase user on server side
 export default defineNuxtPlugin(async () => {
   const user = useSupabaseUser()
-  const client = useSupabaseClient()
+  const authClient = useSupabaseAuthClient()
   const token = useSupabaseToken()
   const route = useRoute()
 
@@ -15,7 +15,7 @@ export default defineNuxtPlugin(async () => {
     return
   }
 
-  const { data: { user: supabaseUser }, error } = await client.auth.getUser(token.value)
+  const { data: { user: supabaseUser }, error } = await authClient.auth.getUser(token.value)
 
   if (error) {
     token.value = null


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
⚠️  This PR involves BREAKING CHANGES ⚠️ 

In order to resolve #114, I have made the choice to separate the `useSupabaseClient` in two other composables:
- The `useSupabaseAuthClient` is dedicated to authentification purpose only. It won't be recreate if your token expires, it is used in the client plugin to listen to `onAuthStateChange` events.
- The `useSupabaseClient` is now only useful for data request.

To avoid regression you just need to use the `useSupabaseAuthClient` instead of the `useSupabaseClient` everywhere you use [Supabase auth methods](https://supabase.com/docs/reference/javascript/auth-signup)

[Documentation](https://supabase.nuxtjs.org/usage/composables/use-supabase-auth-client) has been updated. 
