### PR TITLE
Make auto imports optional

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -3,6 +3,10 @@ import { defu } from 'defu'
 import { defineNuxtModule, addPlugin, addServerHandler, extendViteConfig, createResolver, resolveModule, addTemplate } from '@nuxt/kit'
 import type { SupabaseClientOptions } from '@supabase/supabase-js'
 import { CookieOptions, RedirectOptions } from './runtime/types'
+export { useSupabaseAuthClient } from './runtime/composables/useSupabaseAuthClient'
+export { useSupabaseClient } from './runtime/composables/useSupabaseClient'
+export { useSupabaseToken } from './runtime/composables/useSupabaseToken'
+export { useSupabaseUser } from './runtime/composables/useSupabaseUser'
 
 export interface ModuleOptions {
   /**
@@ -59,6 +63,13 @@ export interface ModuleOptions {
    * @type object
    */
   cookies?: CookieOptions
+  
+  /**
+   * Auto import necessary parts.
+   * @default true
+   * @type boolean
+   */
+  autoImport?: boolean
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -81,7 +92,8 @@ export default defineNuxtModule<ModuleOptions>({
       domain: '',
       path: '/',
       sameSite: 'lax'
-    }
+    },
+    autoImport: true
   },
   setup (options, nuxt) {
     const { resolve } = createResolver(import.meta.url)
@@ -103,7 +115,8 @@ export default defineNuxtModule<ModuleOptions>({
       key: options.key,
       client: options.client,
       redirect: options.redirect,
-      cookies: options.cookies
+      cookies: options.cookies,
+      autoImport: options.autoImport
     })
 
     // Private runtimeConfig
@@ -143,9 +156,11 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     // Add supabase composables
-    nuxt.hook('imports:dirs', (dirs) => {
-      dirs.push(resolve(runtimeDir, 'composables'))
-    })
+    if (options.autoImport) {
+      nuxt.hook('imports:dirs', (dirs) => {
+        dirs.push(resolve(runtimeDir, 'composables'))
+      })
+    }
 
     nuxt.hook('nitro:config', (nitroConfig) => {
       nitroConfig.alias = nitroConfig.alias || {}


### PR DESCRIPTION
Makes it possible to have local composables with the same names as auto-imported ones. Otherwise, auto-imported composables overwrite locale ones.

Please see [here](https://github.com/nuxt-modules/supabase/issues/150#issuecomment-1445137308) why this can be useful.

**/composables/useSupabaseClient.ts**

```ts
import type { Database } from "~/types/database";
import { useSupabaseClient } from "nuxt-modules/supabase";

export default () => useSupabaseClient<Database>();
```

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
