### PR TITLE
docs: add authentication starter template demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [📖 &nbsp;Read the documentation](https://supabase.nuxtjs.org)
 - [▶ &nbsp;Video](https://www.youtube.com/watch?v=jIyiRT6zT8Q)
 - [👾 &nbsp;Demo](./demo)
+- [⚡️ &nbsp;Starter Template](https://github.com/zackha/supaAuth#readme)
 
 ## Features
 


### PR DESCRIPTION
A starter template that is under development to make it easier to build a nuxt project using supabase authentication.