### PR TITLE
Fix broken examples

### DIFF
--- a/docs/content/2.get-started.md
+++ b/docs/content/2.get-started.md
@@ -25,7 +25,7 @@ npm install @nuxtjs/supabase --save-dev
 Then, add `@nuxtjs/supabase` to the `modules` section of `nuxt.config.js`:
 
 ```ts [nuxt.config.ts]
-import { defineNuxtConfig } from 'nuxt'
+import { defineNuxtConfig } from 'nuxt/config'
 
 export default defineNuxtConfig({
   modules: ['@nuxtjs/supabase'],
@@ -44,7 +44,7 @@ SUPABASE_KEY="<your_key>"
 You can configure the supabase module by using the `supabase` key in `nuxt.config`:
 
 ```ts [nuxt.config.ts]
-import { defineNuxtConfig } from 'nuxt'
+import { defineNuxtConfig } from 'nuxt/config'
 
 export default defineNuxtConfig({
   // ...


### PR DESCRIPTION
`defineNuxtConfig` is now within `nuxt/config` and not `nuxt`
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
See compare 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
`defineNuxtConfig` is now within `nuxt/config` and not `nuxt`

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
