### PR TITLE
fix(client): fix persist session warning for `serverSupabaseServiceRole`

### DIFF
--- a/src/runtime/server/services/serverSupabaseServiceRole.ts
+++ b/src/runtime/server/services/serverSupabaseServiceRole.ts
@@ -1,6 +1,7 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import type { H3Event } from 'h3'
 import { useRuntimeConfig } from '#imports'
+import {defu} from "defu";
 
 export const serverSupabaseServiceRole = <T>(event: H3Event): SupabaseClient<T> => {
   const { supabase: { serviceKey }, public: { supabase: { url, client: clientOptions } } } = useRuntimeConfig()
@@ -12,7 +13,15 @@ export const serverSupabaseServiceRole = <T>(event: H3Event): SupabaseClient<T> 
 
   // No need to recreate client if exists in request context
   if (!event.context._supabaseServiceRole) {
-    const supabaseClient = createClient(url, serviceKey, clientOptions)
+    const auth = {
+      detectSessionInUrl: false,
+      persistSession: false,
+      autoRefreshToken: false
+    }
+
+    const options = defu({ auth }, clientOptions)
+
+    const supabaseClient = createClient(url, serviceKey, options)
 
     event.context._supabaseServiceRole = supabaseClient
   }


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Fixes https://github.com/nuxt-modules/supabase/issues/193

Insure that defaults for `auth` are set on the options passed to createClient when using `serverSupabaseServiceRole`.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

Tests not added because existing tests cover the same code.
