### PR TITLE
feat: save provider access/refresh tokens in cookies

### DIFF
--- a/src/runtime/server/api/session.ts
+++ b/src/runtime/server/api/session.ts
@@ -27,6 +27,24 @@ export default defineEventHandler(async (event) => {
       path: cookieOptions.path,
       sameSite: cookieOptions.sameSite as boolean | 'lax' | 'strict' | 'none'
     })
+
+    if (session.provider_token) {
+      setCookie(event, `${cookieOptions.name}-provider-token`, session.provider_token, {
+        domain: cookieOptions.domain,
+        maxAge: cookieOptions.lifetime ?? 0,
+        path: cookieOptions.path,
+        sameSite: cookieOptions.sameSite as boolean | 'lax' | 'strict' | 'none'
+      })
+    }
+
+    if (session.provider_refresh_token) {
+      setCookie(event, `${cookieOptions.name}-provider-refresh-token`, session.provider_refresh_token, {
+        domain: cookieOptions.domain,
+        maxAge: cookieOptions.lifetime ?? 0,
+        path: cookieOptions.path,
+        sameSite: cookieOptions.sameSite as boolean | 'lax' | 'strict' | 'none'
+      })
+    }
   }
 
   if (signEvent === 'SIGNED_OUT') {


### PR DESCRIPTION
## Store provider access/refresh tokens in cookies

This PR stores provider access/refresh tokens in cookies, to allow server routes to use provider APIs.

## Types of changes

- [x] New feature (a non-breaking change which adds functionality)

## Description

When logging in users with external API scopes for a provider (for example, Github), the application will need access to the provider token to access the provider's API. This token is stored in the `session` object, which is only stored in the client (if I'm not mistaken).

When calling an API in my project, only `sb-access-token` and `sb-refresh-token` cookies are sent, which means that if I want to access Github's API from a server route, I won't be able to do so.

As I see it, there are 2 workarounds for this:

1. Store provider's access/refresh tokens in a Supabse table and access that table from server (vanilla, and cumbersome)
2. Store provider's access/refresh tokens in a cookie, so that the server has direct access if needed.

This PR implements the second solution. To access the provider's token from the server, one can simply:

```typescript
export default defineEventHandler((event) => {
  const providerToken = getCookie(event, 'sb-provider-token');

  ...
});
```

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
