### PR TITLE
draft: Tweaked the `useSupabaseClient` consumable to allow for custom schemas

### DIFF
--- a/docs/content/3.usage/1.composables/1.use-supabase-client.md
+++ b/docs/content/3.usage/1.composables/1.use-supabase-client.md
@@ -74,11 +74,25 @@ onUnmounted(() => {
 
 ## Typescript
 
+### Default use-case
 You can pass Database typings to the client. Check Supabase [documentation](https://supabase.com/docs/reference/javascript/release-notes#typescript-support) for further information.
 
 ```vue
 <script setup lang="ts">
 import type { Database } from '~/types'
 const client = useSupabaseClient<Database>()
+</script>
+```
+
+### Custom Schema
+You can pass Database typings to the client with a custom schema as well, when generating supabase types with multiple schemas.
+```Shell
+supabase gen types typescript --project-id put-project-id-here --schema public --schema otherschema > types/index.ts
+```
+Example of using another schema: 
+```vue
+<script setup lang="ts">
+import type { Database } from '~/types'
+const client = useSupabaseClient<Database, 'otherschema'>();
 </script>
 ```

--- a/src/runtime/composables/useSupabaseClient.ts
+++ b/src/runtime/composables/useSupabaseClient.ts
@@ -2,8 +2,16 @@ import { SupabaseClient } from '@supabase/supabase-js'
 import { useNuxtApp } from '#imports'
 import { createSupabaseClient } from '../utils/client'
 import { useSupabaseToken } from '../composables/useSupabaseToken'
+import { GenericSchema } from '@supabase/supabase-js/dist/module/lib/types'
 
-export const useSupabaseClient = <T>(): SupabaseClient<T> => {
+export const useSupabaseClient = <
+  Database,
+  SchemaName extends string & keyof Database = 'public' extends keyof Database
+  ? 'public'
+  : string & keyof Database,
+  Schema extends GenericSchema = Database[SchemaName] extends GenericSchema
+  ? Database[SchemaName]
+  : any>(): SupabaseClient<Database, SchemaName, Schema> => {
   const nuxtApp = useNuxtApp()
   const token = useSupabaseToken()
   const Authorization = token.value ? `Bearer ${token.value}` : undefined
@@ -16,5 +24,5 @@ export const useSupabaseClient = <T>(): SupabaseClient<T> => {
     nuxtApp._supabaseClient = createSupabaseClient()
   }
 
-  return nuxtApp._supabaseAuthClient as SupabaseClient<T>
+  return nuxtApp._supabaseAuthClient as SupabaseClient<Database, SchemaName, Schema>
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Change extends the `useSupabaseClient()` consumable to include the **optional** `SchemaName:string` and `Schema:GenericSchema` custom schema designations that the `SupabaseClient()` [class](https://github.com/supabase/supabase-js/blob/8f5ec5ec4866e286396462c99f4d073e355f565a/src/SupabaseClient.ts#L43-L51) makes use of. 
Anyone generating schema types using the `gen types` command supabase provides with multiple schemas will *NOT* be able to use any schema other than public (at least as far as type-hints are concerned). This PR fixes that limitation. 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
  - There were no tests to apply; the `useSupabaseClient()` consumable was simply extended to support the optional custom schema that is part of the core `@supabase/supabase-js` package via the `SupabaseClient` class (found [here](https://github.com/supabase/supabase-js/blob/8f5ec5ec4866e286396462c99f4d073e355f565a/src/SupabaseClient.ts#L43-L51)). 

