### PR TITLE
fix(typo): correct provider_token assignment to cookie

### DIFF
--- a/src/runtime/plugins/supabase.client.ts
+++ b/src/runtime/plugins/supabase.client.ts
@@ -25,7 +25,7 @@ export default defineNuxtPlugin({
       if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
         useCookie(`${cookieName}-access-token`, cookieOptions).value = session?.access_token
         useCookie(`${cookieName}-refresh-token`, cookieOptions).value = session?.refresh_token
-        if (session.provider_token) useCookie(`${cookieName}-provider-token`, cookieOptions).value = session.access_token
+        if (session.provider_token) useCookie(`${cookieName}-provider-token`, cookieOptions).value = session.provider_token
         if (session.provider_refresh_token) useCookie(`${cookieName}-provider-refresh-token`, cookieOptions).value = session.provider_refresh_token
       }
       if (event === 'SIGNED_OUT') {


### PR DESCRIPTION
# Fix assignment of provider_token in Supabase nuxt module

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
The cookie provider_token was erroneously assigned the value of `session.access_token`. This fixes it
