### PR TITLE
fix(client): return type in useSupabaseUser

### DIFF
--- a/src/runtime/composables/useSupabaseUser.ts
+++ b/src/runtime/composables/useSupabaseUser.ts
@@ -18,5 +18,5 @@ export const useSupabaseUser = () => {
     }
   })
 
-  return user
+  return user as Ref<User>
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
The type is added to the return of the `useSupabaseUser` composable.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

When using the `useSupabaseUser()` composable, it doesn't have types. By adding "as Ref<User>" to it, the generated build automatically introduces the corresponding typing.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
