### PR TITLE
Add explicit user type to work around build issue

### DIFF
--- a/src/runtime/composables/useSupabaseUser.ts
+++ b/src/runtime/composables/useSupabaseUser.ts
@@ -1,4 +1,5 @@
 import type { User } from '@supabase/supabase-js'
+import type { Ref } from 'vue'
 import { useSupabaseClient } from './useSupabaseClient'
 import { useState } from '#imports'
 
@@ -18,5 +19,5 @@ export const useSupabaseUser = () => {
     }
   })
 
-  return user
+  return user as Ref<User | null>
 }


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
This adds an explicit typecast to the returned `user` object from `useSupabaseUser`. When built, the annotation is picked up and added to the `.d.ts` file. Since 1.0.0-0 the type was inferred as `any`. 

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

There are no tests for the `.d.ts` output. Probably this is caused by a bug upstream and needs a test there.