### PR TITLE
🐛 Makes `useSupabaseUser` an async function, to resolve the `missing subclaim` race condition when using backend calls after login

### DIFF
--- a/docs/content/3.authentication.md
+++ b/docs/content/3.authentication.md
@@ -67,9 +67,11 @@ The redirect URL must be configured in your Supabase dashboard under `Authentica
 ```vue [pages/confirm.vue]
 <script setup lang="ts">
 const user = useSupabaseUser()
-if (user.value) {
-  return navigateTo('/')
-}
+watch(user, () => {
+  if (user.value) {
+    return navigateTo('/')
+  }
+}, { immediate: true })
 
 </script>
 <template>

--- a/src/runtime/composables/useSupabaseUser.ts
+++ b/src/runtime/composables/useSupabaseUser.ts
@@ -1,21 +1,22 @@
 import type { User } from '@supabase/supabase-js'
 import { useState } from '#imports'
 
-export const useSupabaseUser = () => {
+export const useSupabaseUser = async () => {
   const supabase = useSupabaseClient()
 
   const user = useState<User | null>('supabase_user', () => null)
 
   // Asyncronous refresh session and ensure user is still logged in
-  supabase?.auth.getSession().then(({ data: { session } }) => {
-    if (session) {
-      if (JSON.stringify(user.value) !== JSON.stringify(session.user)) {
-        user.value = session.user;
-      }
-    } else {
-      user.value = null
+  const sessionData = await supabase?.auth.getSession()
+  const session = sessionData.data.session
+
+  if (session) {
+    if (JSON.stringify(user.value) !== JSON.stringify(session.user)) {
+      user.value = session.user
     }
-  })
+  } else {
+    user.value = null
+  }
 
   return user as Ref<User | null>
 }

--- a/src/runtime/plugins/auth-redirect.ts
+++ b/src/runtime/plugins/auth-redirect.ts
@@ -6,7 +6,7 @@ export default defineNuxtPlugin({
   setup() {
     addRouteMiddleware(
       'global-auth',
-      defineNuxtRouteMiddleware(to => {
+      defineNuxtRouteMiddleware(async to => {
         const config = useRuntimeConfig().public.supabase
         const { login, callback, exclude } = config.redirectOptions
 
@@ -17,7 +17,7 @@ export default defineNuxtPlugin({
         })
         if (isExcluded) return
 
-        const user = useSupabaseUser()
+        const user = await useSupabaseUser()
         if (!user.value) {
           return navigateTo(login)
         }


### PR DESCRIPTION
* Changes `useSupabaseUser` as a async function
* Rewrite logic to properly encapsulate the current asynchronous logic within the composable with `await` functions instead

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)


## Description

This should help address the problems in #238 

Currently, the logic for the `useSupabaseUser` function calls a promise but does not await the outcome, leading to a potential race condition that may cause any actions based on the value of `useSupabaseUser` to not have the correct data if it's still pending;

In my current project, this logic causes an issue where I would get the `invalid claim: missing sub claim` error when I would make a call to an endpoint in my Nuxt `/api`  that was using the `serverSupabaseUser` method--which is properly handled as an asynchronous method.  This would usually only happen on the first call right on login, and resolve after refreshing the page.

[Looking into the error, it looked to be caused by not awaiting session data correctly](https://github.com/supabase/supabase-js/issues/641#issuecomment-1573305325).  Given that we use a cookie passed back to the Nuxt API routes to ensure that server-side auth works, I thought that having the composable immediately pass back the user session without properly waiting for the promise to resolve may result in conditions where the session cookie may or may not be properly set, but API calls that look for a cookie to be set may be called with the expectation that it has.

After making the changes below, I no longer have this issue in my project when watching the `useSupabaseUser` value to make API calls

HOWEVER, I'm aware this is a breaking change.  I'm not sure why we do not currently await the promise within the composable as it stands, but if there is a legitimate reason, I'd kindly ask that we at least offer a new composable called `useAsyncSupabaseUser` or something similar to allow this functionality for those who want it, or are experiencing similar issues to mine

## Checklist:
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
  * Happy to add these, I want to make sure these changes make sense before continuing
- [ ] I have added tests to cover my changes (if not applicable, please state why)
  * Happy to add these, I want to make sure these changes make sense before continuing
