### PR TITLE
fix: do not warn when using runtimeConfig to set url and key

### DIFF
--- a/docs/content/2.get-started.md
+++ b/docs/content/2.get-started.md
@@ -40,10 +40,14 @@ export default defineNuxtConfig({
 
 Add `SUPABASE_URL` and `SUPABASE_KEY` to the `.env`:
 
-```zsh [.env]
+```zsh [env]
 SUPABASE_URL="https://example.supabase.co"
 SUPABASE_KEY="<your_key>"
 ```
+
+::alert
+Alternatively, you can prefix the env variables with `NUXT_PUBLIC_` in order to use runtimeConfig.
+::
 
 ## Options
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -123,16 +123,6 @@ export default defineNuxtModule<ModuleOptions>({
     const { resolve } = createResolver(import.meta.url)
     const resolveRuntimeModule = (path: string) => resolveModule(path, { paths: resolve('./runtime') })
 
-    // Make sure url and key are set
-    if (!options.url) {
-      // eslint-disable-next-line no-console
-      console.warn('Missing `SUPABASE_URL` in `.env`')
-    }
-    if (!options.key) {
-      // eslint-disable-next-line no-console
-      console.warn('Missing `SUPABASE_KEY` in `.env`')
-    }
-
     // Public runtimeConfig
     nuxt.options.runtimeConfig.public.supabase = defu(nuxt.options.runtimeConfig.public.supabase, {
       url: options.url,
@@ -149,6 +139,15 @@ export default defineNuxtModule<ModuleOptions>({
       serviceKey: options.serviceKey
     })
 
+    // Make sure url and key are set
+    if (!nuxt.options.runtimeConfig.public.supabase.url) {
+      // eslint-disable-next-line no-console
+      console.warn('Missing supabase url, set it either in `nuxt.config.js` or via env variable')
+    }
+    if (!nuxt.options.runtimeConfig.public.supabase.key) {
+      // eslint-disable-next-line no-console
+      console.warn('Missing supabase anon key, set it either in `nuxt.config.js` or via env variable')
+    }
     
     // ensure callback URL is not using SSR
     const mergedOptions = nuxt.options.runtimeConfig.public.supabase


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
When using `runtimeConfig` environment variables, everything works, but a warning appear.

This PR test key and url after having merged module with `runtimeConfig` to detect if they are provided.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
