### PR TITLE
fix(client): prevent useCookie usage outside of effect scope

### DIFF
--- a/src/runtime/plugins/supabase.client.ts
+++ b/src/runtime/plugins/supabase.client.ts
@@ -12,6 +12,11 @@ export default defineNuxtPlugin({
 
     const supabaseClient = createClient(url, key, clientOptions)
 
+    const accessToken = useCookie(`${cookieName}-access-token`, cookieOptions);
+    const refreshToken = useCookie(`${cookieName}-refresh-token`, cookieOptions);
+    const providerToken = useCookie(`${cookieName}-provider-token`, cookieOptions);
+    const providerRefreshToken = useCookie(`${cookieName}-provider-refresh-token`, cookieOptions);
+
     // Handle auth event client side
     supabaseClient.auth.onAuthStateChange(async (event, session) => {
       // Update user based on received session
@@ -25,16 +30,16 @@ export default defineNuxtPlugin({
 
       // Use cookies to share session state between server and client
       if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
-        useCookie(`${cookieName}-access-token`, cookieOptions).value = session?.access_token
-        useCookie(`${cookieName}-refresh-token`, cookieOptions).value = session?.refresh_token
-        if (session.provider_token) useCookie(`${cookieName}-provider-token`, cookieOptions).value = session.provider_token
-        if (session.provider_refresh_token) useCookie(`${cookieName}-provider-refresh-token`, cookieOptions).value = session.provider_refresh_token
+        accessToken.value = session?.access_token
+        refreshToken.value = session?.refresh_token
+        if (session.provider_token) providerToken.value = session.provider_token
+        if (session.provider_refresh_token) providerRefreshToken.value = session.provider_refresh_token
       }
       if (event === 'SIGNED_OUT') {
-        useCookie(`${cookieName}-access-token`, cookieOptions).value = null
-        useCookie(`${cookieName}-refresh-token`, cookieOptions).value = null
-        useCookie(`${cookieName}-provider-token`, cookieOptions).value = null
-        useCookie(`${cookieName}-provider-refresh-token`, cookieOptions).value = null
+        accessToken.value = null
+        refreshToken.value = null
+        providerToken.value = null
+        providerRefreshToken.value = null
       }
     })
 


### PR DESCRIPTION
Don't call `useCookie` in `onAuthStateChange`, as this leads to incorrect behavior and warnings during development.
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

`useCookie` is called in `onAuthStateChange` which is called outside of the Vue effect scope. This triggers the following warning in dev: `[Vue warn] onScopeDispose() is called when there is no active effect scope to be associated with.`. This warning is muted in prod but the behavior of `useCookie` subtly changes.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
