### PR TITLE
chore: use module-builder stub mode for more accurate types

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
-    "dev:prepare": "nuxt-module-build --stub && nuxi prepare playground",
+    "dev:prepare": "nuxt-module-build --stub && nuxt-module-build prepare && nuxi prepare playground",
     "build": "nuxt-module-build build",
     "lint": "eslint --ext .js,.ts,.vue .",
     "release": "pnpm lint && release-it",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./playground/.nuxt/tsconfig.json",
+  "extends": "./.nuxt/tsconfig.json",
   "compilerOptions": {
     "strictNullChecks": false
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

We added a `prepare` command for nuxt-module-build which allows creating type stubs directly from the module without needing to apply to the playground as well. (https://github.com/nuxt/module-builder/pull/124)

It's the default for new modules (https://github.com/nuxt/starter/pull/392).

This should allow us to match types more appropriately for module authors (for example, disallowing auto-imports) in future.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
