### PR TITLE
feat(app): added redirect path cookie for use after signin

### DIFF
--- a/docs/content/2.get-started.md
+++ b/docs/content/2.get-started.md
@@ -98,11 +98,13 @@ Default:
     login: '/login',
     callback: '/confirm',
     exclude: [],
+    cookieRedirect: false,
   }
 ```
 - `login`: User will be redirected to this path if not authenticated or after logout. 
 - `callback`: This is the path the user will be redirect to after supabase login redirection. Should match configured `redirectTo` option of your [signIn method](https://supabase.com/docs/reference/javascript/auth-signinwithoauth). Should also be configured in your Supabase dashboard under `Authentication -> URL Configuration -> Redirect URLs`.
 - `exclude`: Routes to exclude from the redirect. `['/foo', '/bar/*']` will exclude the `foo` page and all pages in your `bar` folder.
+- `cookieRedirect`: Sets a cookie containing the path an unauthenticated user tried to access. The cookie can then be used on the [`/confirm`](https://supabase.nuxtjs.org/authentication#confirm-page-confirm) page to redirect the user to the page they previously tried to visit. 
 
 ### `cookieName`
 

--- a/docs/content/3.authentication.md
+++ b/docs/content/3.authentication.md
@@ -65,9 +65,17 @@ The redirect URL must be configured in your Supabase dashboard under `Authentica
 ```vue [pages/confirm.vue]
 <script setup lang="ts">
 const user = useSupabaseUser()
+
+// Pull in the config to get cookie details
+const config = useRuntimeConfig().public.supabase;
+const { cookieName } = config;
+const redirectPath = useCookie(`${cookieName}-redirect-path`).value;
+
+
 watch(user, () => {
   if (user.value) {
-    return navigateTo('/')
+      useCookie(`${cookieName}-redirect-path`).value = null // Clear the cookie
+      return navigateTo(redirectPath || '/'); // Redirect or go to protected page
   }
 }, { immediate: true })
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -102,7 +102,8 @@ export default defineNuxtModule<ModuleOptions>({
     redirectOptions: {
       login: '/login',
       callback: '/confirm',
-      exclude: []
+      exclude: [],
+      cookieRedirect: false
     },
     cookieName: 'sb',
     cookieOptions: {
@@ -151,8 +152,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // ensure callback URL is not using SSR
     const mergedOptions = nuxt.options.runtimeConfig.public.supabase
-    if (mergedOptions.redirect &&
-      mergedOptions.redirectOptions.callback) {
+    if (mergedOptions.redirect && mergedOptions.redirectOptions.callback) {
       const routeRules: { [key: string]: any } = {}
       routeRules[mergedOptions.redirectOptions.callback] = { ssr: false }
       nuxt.options.nitro = defu(nuxt.options.nitro, {

--- a/src/runtime/plugins/auth-redirect.ts
+++ b/src/runtime/plugins/auth-redirect.ts
@@ -1,5 +1,5 @@
 import { useSupabaseUser } from '../composables/useSupabaseUser'
-import { defineNuxtPlugin, addRouteMiddleware, defineNuxtRouteMiddleware, useRuntimeConfig, navigateTo } from '#imports'
+import { defineNuxtPlugin, addRouteMiddleware, defineNuxtRouteMiddleware, useCookie, useRuntimeConfig, navigateTo } from '#imports'
 
 export default defineNuxtPlugin({
   name: 'auth-redirect',
@@ -8,7 +8,8 @@ export default defineNuxtPlugin({
       'global-auth',
       defineNuxtRouteMiddleware((to) => {
         const config = useRuntimeConfig().public.supabase
-        const { login, callback, exclude } = config.redirectOptions
+        const { login, callback, exclude, cookieRedirect } = config.redirectOptions
+        const { cookieName, cookieOptions } = config
 
         // Do not redirect on login route, callback route and excluded routes
         const isExcluded = [...exclude, login, callback]?.some((path) => {
@@ -19,6 +20,7 @@ export default defineNuxtPlugin({
 
         const user = useSupabaseUser()
         if (!user.value) {
+          if (cookieRedirect) { useCookie(`${cookieName}-redirect-path`, cookieOptions).value = to.fullPath }
           return navigateTo(login)
         }
       }),

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -18,4 +18,5 @@ export interface RedirectOptions {
   login: string
   callback: string
   exclude?: string[]
+  cookieRedirect?: boolean
 }


### PR DESCRIPTION
Added a feature to store the requested route that is outside the scope of the excluded routes. The route is stored in a cookie and disabled by default.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
I needed a way to have my application users be able to share a link to a page with users who potentially would not be registered or logged in. This Pull Request adds a cookie that is set when the client tries to hit a route that is not listed in the `redirectOptions.exclude` list, it then sets the cookie equal to the `route.to.fullPath` to include capturing the url parameters.

I couldn't just use the redirectTo when using OAuth because using the `redirect: true` makes the module's middleware leave the route and always report it as `/login`. I needed to capture the route BEFORE the Supabase `auth-redirect.mjs` middleware performed the redirect to the login page.

I set my nuxt.config.ts values to reflect the changes:
```ts
export default defineNuxtConfig({
  supabase: {
    redirect: true,
    redirectOptions: {
      login: '/login',
      callback: '/dashboard',
      exclude: ['/', '/register', '/privacy-policy','/confirm'], // MUST have confirm or it will loop to /login every time
      cookieRedirect: true, // Enable the storing of the requested route
    },
  }
  // Rest of your config
});

```


This pull request has a modification to the `/pages/confirm.vue` in order to get the cookie.
```html
<script setup lang="ts">
const user = useSupabaseUser();

// Pull in the config to get cookie details
const config = useRuntimeConfig().public.supabase;
const { cookieName } = config;
const redirectPath = useCookie(`${cookieName}-redirect-path`).value;

watch(
  user,
  () => {
    if (user.value) {
      useCookie(`${cookieName}-redirect-path`).value = null // Clear the cookie
      return navigateTo(redirectPath || '/'); // Redirect or go to protected page
    }
  },
  { immediate: true },
);
</script>
<template>
  <div>
    <p>Waiting for login...</p>
  </div>
</template>
```




## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
