### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/docs/content/2.get-started.md
+++ b/docs/content/2.get-started.md
@@ -18,22 +18,6 @@ Add `@nuxtjs/supabase` dev dependency to your project:
 ```bash
 npx nuxi@latest module add supabase
 ```
-<<<<<<< Updated upstream
-
-```bash [yarn]
-yarn add --dev @nuxtjs/supabase
-```
-
-```bash [NPM]
-npm install @nuxtjs/supabase --save-dev
-```
-
-```bash [bun]
-bun add -D @nuxtjs/supabase
-```
-::
-=======
->>>>>>> Stashed changes
 
 Add `@nuxtjs/supabase` to the `modules` section of `nuxt.config.ts`:
 

--- a/docs/content/2.get-started.md
+++ b/docs/content/2.get-started.md
@@ -15,11 +15,10 @@ For integrating Supabase with Nuxt 2, checkout [supabase-community/nuxt-supabase
 ## Installation
 
 Add `@nuxtjs/supabase` dev dependency to your project:
-
-::code-group
-```bash [pnpm]
-pnpm add -D @nuxtjs/supabase
+```bash
+npx nuxi@latest module add supabase
 ```
+<<<<<<< Updated upstream
 
 ```bash [yarn]
 yarn add --dev @nuxtjs/supabase
@@ -33,6 +32,8 @@ npm install @nuxtjs/supabase --save-dev
 bun add -D @nuxtjs/supabase
 ```
 ::
+=======
+>>>>>>> Stashed changes
 
 Add `@nuxtjs/supabase` to the `modules` section of `nuxt.config.ts`:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏



## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
