### PR TITLE
Only fetch supabase?.auth.getSession() once

### DIFF
--- a/playground/pages/user.vue
+++ b/playground/pages/user.vue
@@ -3,10 +3,14 @@
 const supabase = useSupabaseClient()
 const user = useSupabaseUser()
 const router = useRouter()
+const session = useSupabaseSession()
+
 if (process.server) {
-  console.log('User on server side: ', user.value)
+  console.log('User on server side: ', user.value?.email)
+  console.log('Session on server side: ', session.value?.user?.email)
 } else {
-  console.log('User on client side: ', user.value)
+  console.log('User on client side: ', user.value?.email)
+  console.log('Session on client side: ', session.value?.user?.email)
 }
 const signOut = async () => {
   const { error } = await supabase.auth.signOut()

--- a/src/runtime/composables/useSupabaseSession.ts
+++ b/src/runtime/composables/useSupabaseSession.ts
@@ -3,7 +3,7 @@ import type { Ref } from 'vue'
 import { useSupabaseClient } from './useSupabaseClient'
 import { useState } from '#imports'
 
-export const useSupabaseSession = () => {
+export const useSupabaseSession: () => Ref<Session | null> = () => {
   const supabase = useSupabaseClient()
 
   const sessionState = useState<Session | null>('supabase_session', () => null)
@@ -19,5 +19,5 @@ export const useSupabaseSession = () => {
     }
   })
 
-  return sessionState as Ref<Session | null>
+  return sessionState
 }

--- a/src/runtime/composables/useSupabaseUser.ts
+++ b/src/runtime/composables/useSupabaseUser.ts
@@ -1,23 +1,9 @@
+import { useSupabaseSession } from './useSupabaseSession'
+import { computed, type ComputedRef } from '#imports'
 import type { User } from '@supabase/supabase-js'
-import type { Ref } from 'vue'
-import { useSupabaseClient } from './useSupabaseClient'
-import { useState } from '#imports'
 
-export const useSupabaseUser = () => {
-  const supabase = useSupabaseClient()
-
-  const user = useState<User | null>('supabase_user', () => null)
-
-  // Asyncronous refresh session and ensure user is still logged in
-  supabase?.auth.getSession().then(({ data: { session } }) => {
-    if (session) {
-      if (JSON.stringify(user.value) !== JSON.stringify(session.user)) {
-        user.value = session.user
-      }
-    } else {
-      user.value = null
-    }
-  })
-
-  return user as Ref<User | null>
+export const useSupabaseUser: () => ComputedRef<User | null> = () => {
+  const session = useSupabaseSession()
+  const userState = computed(() => session.value?.user)
+  return userState
 }

--- a/src/runtime/plugins/supabase.client.ts
+++ b/src/runtime/plugins/supabase.client.ts
@@ -7,7 +7,6 @@ export default defineNuxtPlugin({
   name: 'supabase',
   enforce: 'pre',
   async setup () {
-    const user = useSupabaseUser()
     const currentSession = useSupabaseSession()
     const config = useRuntimeConfig().public.supabase
     const { url, key, cookieName, cookieOptions, clientOptions } = config
@@ -25,12 +24,9 @@ export default defineNuxtPlugin({
       if (session) {
         if (JSON.stringify(currentSession) !== JSON.stringify(session)) {
           currentSession.value = session
-          if (JSON.stringify(user.value) !== JSON.stringify(session.user)) {
-            user.value = session.user
-          }
         }
       } else {
-        user.value = null
+        currentSession.value = null
       }
 
       // Use cookies to share session state between server and client

--- a/src/runtime/plugins/supabase.server.ts
+++ b/src/runtime/plugins/supabase.server.ts
@@ -1,13 +1,12 @@
 import { defu } from 'defu'
 import { createClient } from '@supabase/supabase-js'
-import { useSupabaseUser } from '../composables/useSupabaseUser'
 import { useSupabaseSession } from '../composables/useSupabaseSession'
 import { defineNuxtPlugin, useRuntimeConfig, useCookie } from '#imports'
 
 export default defineNuxtPlugin({
   name: 'supabase',
   enforce: 'pre',
-  async setup () {
+  async setup() {
     const { url, key, cookieName, clientOptions } = useRuntimeConfig().public.supabase
     const accessToken = useCookie(`${cookieName}-access-token`).value
     const refreshToken = useCookie(`${cookieName}-refresh-token`).value
@@ -31,9 +30,6 @@ export default defineNuxtPlugin({
       })
       if (data) {
         useSupabaseSession().value = data.session
-        if (data?.user) {
-          useSupabaseUser().value = data.user
-        }
       }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Improvement (a non-breaking change which improve the library)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

By looking into the code, I realize that composables `useSupabaseUser()` and `useSupabaseSession()` are calling the same Supabase API in order to get almost the same information. 

On both, they call `supabase?.auth.getSession()`. `useSupabaseSession()` get the session like this and `useSupabaseUser()` get the user from the session.

We can improve this by:
- Letting `useSupabaseSession()` fetch the session from Supabase
- Compute the user of `useSupabaseUser()` from `useSupabaseSession()` because session contains the user

We gain an API call and it's a little bit easier to maintain because the value of `useSupabaseUser()` is strongly linked to `useSupabaseSession()` value. Each time the session changes, the user will update automatically.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
