### PR TITLE
[docs] Update 2.get-started.md

### DIFF
--- a/docs/content/2.get-started.md
+++ b/docs/content/2.get-started.md
@@ -122,10 +122,10 @@ The path for the generated Supabase TypeScript definitions. The database definit
 
 ```bash
 ## Generate types from live database
-supabase gen types typescript --project-id YourProjectId > types/database.types.ts
+supabase gen types --lang=typescript --project-id YourProjectId > types/database.types.ts
 
 ## Generate types when using local environment
-supabase gen types typescript --local > types/database.types.ts
+supabase gen types --lang=typescript --local > types/database.types.ts
 ```
 
 Set to `false` to disable.


### PR DESCRIPTION
## Types of changes
Docs change


## Description
Supabase CLI changed, it now shows: `Command "typescript" is deprecated, use "gen types --lang=typescript" instead.` when doing `supabase gen types typescript`. This PR changes the docs accordingly.


## Checklist:
Docs change so no further actions needed.