### PR TITLE
Add support for database types on different schemas.

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -204,10 +204,10 @@ export default defineNuxtModule<ModuleOptions>({
       filename: 'types/supabase-database.d.ts',
       getContents: async () => {
         if (!!options.types && fs.existsSync(await resolvePath(options.types))) {
-          return `export * from '${await resolvePath(options.types)}'`
+          return `export * from '${await resolvePath(options.types)}'; export type Schema = ${JSON.stringify(options?.clientOptions?.db?.schema || 'public')};`
         }
 
-        return `export type Database = unknown`
+        return `export type Database = unknown; export type Schema = ${JSON.stringify(options?.clientOptions?.db?.schema || 'public')};`
       },
     })
 

--- a/src/runtime/composables/useSupabaseClient.ts
+++ b/src/runtime/composables/useSupabaseClient.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { useNuxtApp } from '#imports'
-import type { Database } from '#build/types/supabase-database'
+import type { Database, Schema } from '#build/types/supabase-database'
 
-export const useSupabaseClient = <T = Database>() => {
-  return useNuxtApp().$supabase?.client as SupabaseClient<T>
+export const useSupabaseClient = <T = Database, S extends string & keyof T = Schema>() => {
+  return useNuxtApp().$supabase?.client as SupabaseClient<T, S>
 }

--- a/src/runtime/server/services/serverSupabaseClient.ts
+++ b/src/runtime/server/services/serverSupabaseClient.ts
@@ -2,9 +2,9 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import { createServerClient, parseCookieHeader, type CookieOptions } from '@supabase/ssr'
 import { getHeader, setCookie, type H3Event } from 'h3'
 import { useRuntimeConfig } from '#imports'
-import type { Database } from '#build/types/supabase-database'
+import type { Database, Schema } from '#build/types/supabase-database'
 
-export const serverSupabaseClient = async <T = Database>(event: H3Event): Promise<SupabaseClient<T>> => {
+export const serverSupabaseClient = async <T = Database, S extends string & keyof T = Schema>(event: H3Event): Promise<SupabaseClient<T, S>> => {
   // No need to recreate client if exists in request context
   if (!event.context._supabaseClient) {
     // get settings from runtime config

--- a/src/runtime/server/services/serverSupabaseServiceRole.ts
+++ b/src/runtime/server/services/serverSupabaseServiceRole.ts
@@ -2,9 +2,9 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import { createClient } from '@supabase/supabase-js'
 import type { H3Event } from 'h3'
 import { useRuntimeConfig } from '#imports'
-import type { Database } from '#build/types/supabase-database'
+import type { Database, Schema } from '#build/types/supabase-database'
 
-export const serverSupabaseServiceRole = <T = Database>(event: H3Event): SupabaseClient<T> => {
+export const serverSupabaseServiceRole = <T = Database, S extends string & keyof T = Schema>(event: H3Event): SupabaseClient<T, S> => {
   const {
     supabase: { serviceKey },
     public: {


### PR DESCRIPTION
This plumbs through a `config`-set schema name to the types system.

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Currently, types do not correctly reflect overridden schemas. This PR allows that schema to be plumbed through reasonably.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
Not sure what tests apply here.