### PR TITLE
Directly throw Supabase error in server utility functions

### DIFF
--- a/src/runtime/server/services/serverSupabaseSession.ts
+++ b/src/runtime/server/services/serverSupabaseSession.ts
@@ -1,15 +1,12 @@
 import type { Session } from '@supabase/supabase-js'
 import type { H3Event } from 'h3'
-import { createError } from 'h3'
 import { serverSupabaseClient } from '../services/serverSupabaseClient'
 
 export const serverSupabaseSession = async (event: H3Event): Promise<Session | null> => {
   const client = await serverSupabaseClient(event)
 
   const { data: { session }, error } = await client.auth.getSession()
-  if (error) {
-    throw createError({ statusMessage: error?.message })
-  }
+  if (error) throw error
 
   return session
 }

--- a/src/runtime/server/services/serverSupabaseUser.ts
+++ b/src/runtime/server/services/serverSupabaseUser.ts
@@ -1,15 +1,12 @@
 import type { User } from '@supabase/supabase-js'
 import type { H3Event } from 'h3'
-import { createError } from 'h3'
 import { serverSupabaseClient } from '../services/serverSupabaseClient'
 
 export const serverSupabaseUser = async (event: H3Event): Promise<User | null> => {
   const client = await serverSupabaseClient(event)
 
   const { data: { user }, error } = await client.auth.getUser()
-  if (error) {
-    throw createError({ statusMessage: error?.message })
-  }
+  if (error) throw error
 
   return user
 }


### PR DESCRIPTION
## Remove opinionated use of `createError` in favor of direct throw for better error handling

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
This change removes the use of `createError` and replaces it with a direct `throw`. This modification allows downstream users more flexibility in catching and handling errors, fitting the specific needs of their applications.

### Why is this change required? What problem does it solve?
The previous implementation using `createError` restricted how errors could be caught and handled by downstream users. By directly throwing errors, developers now have the ability to catch and manage these errors in a way that best suits their application's requirements.

### Resolves: N/A

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
