### PR TITLE
fix: ssr getSession warning

### DIFF
--- a/src/runtime/composables/useSupabaseSession.ts
+++ b/src/runtime/composables/useSupabaseSession.ts
@@ -5,4 +5,4 @@ import { useState, type Ref } from '#imports'
  * Reactive `Session` state from Supabase. This is initialized in both client and server plugin
  * and, on the client, also updated through `onAuthStateChange` events.
  */
-export const useSupabaseSession = (): Ref<Session | null> => useState<Session | null>('supabase_session', () => null)
+export const useSupabaseSession = (): Ref<Omit<Session, 'user'> | null> => useState<Omit<Session, 'user'> | null>('supabase_session', () => null)

--- a/src/runtime/plugins/supabase.server.ts
+++ b/src/runtime/plugins/supabase.server.ts
@@ -1,7 +1,7 @@
 import { createServerClient, parseCookieHeader } from '@supabase/ssr'
 import { getHeader, setCookie } from 'h3'
 import { fetchWithRetry } from '../utils/fetch-retry'
-import { serverSupabaseUser, serverSupabaseSession } from '#supabase/server'
+import { serverSupabaseUser, serverSupabaseSession } from '../server/services'
 import { defineNuxtPlugin, useRequestEvent, useRuntimeConfig, useSupabaseSession, useSupabaseUser } from '#imports'
 import type { CookieOptions } from '#app'
 
@@ -36,7 +36,11 @@ export default defineNuxtPlugin({
     const [
       session,
       user,
-    ] = await Promise.all([serverSupabaseSession(event), serverSupabaseUser(event)])
+    ] = await Promise.all([
+      serverSupabaseSession(event).catch(() => null),
+      serverSupabaseUser(event).catch(() => null),
+    ])
+
     useSupabaseSession().value = session
     useSupabaseUser().value = user
 

--- a/src/runtime/plugins/supabase.server.ts
+++ b/src/runtime/plugins/supabase.server.ts
@@ -1,6 +1,7 @@
 import { createServerClient, parseCookieHeader } from '@supabase/ssr'
 import { getHeader, setCookie } from 'h3'
 import { fetchWithRetry } from '../utils/fetch-retry'
+import { serverSupabaseUser, serverSupabaseSession } from '#supabase/server'
 import { defineNuxtPlugin, useRequestEvent, useRuntimeConfig, useSupabaseSession, useSupabaseUser } from '#imports'
 import type { CookieOptions } from '#app'
 
@@ -33,15 +34,9 @@ export default defineNuxtPlugin({
 
     // Initialize user and session states
     const [
-      {
-        data: { session },
-      },
-      {
-        data: { user },
-      },
-    ] = await Promise.all([client.auth.getSession(), client.auth.getUser()])
-    // @ts-expect-error we need to delete user from the session object here to suppress the warning coming from GoTrueClient
-    delete session?.user
+      session,
+      user,
+    ] = await Promise.all([serverSupabaseSession(event), serverSupabaseUser(event)])
     useSupabaseSession().value = session
     useSupabaseUser().value = user
 

--- a/src/runtime/plugins/supabase.server.ts
+++ b/src/runtime/plugins/supabase.server.ts
@@ -40,6 +40,8 @@ export default defineNuxtPlugin({
         data: { user },
       },
     ] = await Promise.all([client.auth.getSession(), client.auth.getUser()])
+    // @ts-expect-error we need to delete user from the session object here to suppress the warning coming from GoTrueClient
+    delete session?.user
     useSupabaseSession().value = session
     useSupabaseUser().value = user
 

--- a/src/runtime/server/services/serverSupabaseSession.ts
+++ b/src/runtime/server/services/serverSupabaseSession.ts
@@ -3,7 +3,7 @@ import type { H3Event } from 'h3'
 import { createError } from 'h3'
 import { serverSupabaseClient } from '../services/serverSupabaseClient'
 
-export const serverSupabaseSession = async (event: H3Event): Promise<Session | null> => {
+export const serverSupabaseSession = async (event: H3Event): Promise<Omit<Session, 'user'> | null> => {
   const client = await serverSupabaseClient(event)
 
   const { data: { session }, error } = await client.auth.getSession()
@@ -11,5 +11,7 @@ export const serverSupabaseSession = async (event: H3Event): Promise<Session | n
     throw createError({ statusMessage: error?.message })
   }
 
+  // @ts-expect-error we need to delete user from the session object here to suppress the warning coming from GoTrueClient
+  delete session?.user
   return session
 }


### PR DESCRIPTION
## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change)

## Description

This PR addresses a warning that occurs when calling `supabase.auth.getSession()` on the server:

```
 WARN  Using the user object as returned from supabase.auth.getSession() or from some supabase.auth.onAuthStateChange() events could be insecure! This value comes directly from the storage medium (usually cookies on the server) and may not be authentic. Use supabase.auth.getUser() instead, which authenticates the data by contacting the Supabase Auth server.
```

To resolve this, the `user` property is removed from the session object within the server plugin. This prevents the `user` prop from being accessed and stops the warning from being logged.

An alternative approach, without deleting the `user` object, could be:

```ts
useSupabaseSession().value = session
  ? {
      access_token: session.access_token,
      expires_in: session.expires_in,
      token_type: session.token_type,
      refresh_token: session.refresh_token,
      provider_token: session.provider_token,
      provider_refresh_token: session.provider_refresh_token,
      expires_at: session.expires_at,
    }
  : null;
```

## Checklist

- [x] Tested this change with the demo project.