### PR TITLE
Add security advise to serverSupabaseSession

### DIFF
--- a/docs/content/4.usage/services/3.serverSupabaseSession.md
+++ b/docs/content/4.usage/services/3.serverSupabaseSession.md
@@ -9,6 +9,10 @@ This section assumes you're familiar with [Nitro](https://v3.nuxtjs.org/guide/co
 
 This function is similar to the [useSupabaseSession](/usage/composables/usesupabasesession) composable but is used in [server routes](https://nuxt.com/docs/guide/directory-structure/server#server-routes).
 
+::callout{color="amber" icon="i-heroicons-exclamation-triangle-20-solid"}
+Be advised that `serverSupabaseSession` is considered unsafe, since the session comes from the client and users can tamper with it. For checking if the user is logged in, always use  [serverSupabaseUser](/usage/services/serversupabaseuser)
+::
+
 Define your server route and import the `serverSupabaseSession` from `#supabase/server`.
 
 ```ts [server/api/session.ts]


### PR DESCRIPTION
Its not really clear in both the Supabase and these docs that serverSupabaseSession is unsafe for checking if the user is logged in or not. This note might prevent some developers from making this mistake.