### PR TITLE
docs(redirectOptions): fix exclude wildcard example

### DIFF
--- a/docs/content/2.get-started.md
+++ b/docs/content/2.get-started.md
@@ -93,7 +93,7 @@ Default:
 - `login`: User will be redirected to this path if not authenticated or after logout.
 - `callback`: This is the path the user will be redirect to after supabase login redirection. Should match configured `redirectTo` option of your [signIn method](https://supabase.com/docs/reference/javascript/auth-signinwithoauth). Should also be configured in your Supabase dashboard under `Authentication -> URL Configuration -> Redirect URLs`.
 - `include`: Routes to include in the redirect. `['/admin(/*)?']` will enable the redirect only for the `admin` page and all sub-pages.
-- `exclude`: Routes to exclude from the redirect. `['/foo', '/bar/*']` will exclude the `foo` page and all pages in your `bar` folder.
+- `exclude`: Routes to exclude from the redirect. `['/foo', '/bar/**']` will exclude the `foo` page and all pages in your `bar` folder.
 - `cookieRedirect`: Sets a cookie containing the path an unauthenticated user tried to access. The cookie can then be used on the [`/confirm`](https://supabase.nuxtjs.org/authentication#confirm-page-confirm) page to redirect the user to the page they previously tried to visit.
 
 ### `cookieName`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation change/clarification


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
I tried adding `/api/scan/*` to my `supabase.redirectOptions.exclude` array in my Nuxt config, but it did not match a server route (`server/api/scan/[id].ts`), whereas `/api/scan/**` seems to work – let me know if this is expected or i'm "holding it wrong". If this is the expected usage, then I've proposed a docs update.

_P.S. Thanks for the module! :3_

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
