### PR TITLE
Pass H3Event into useRuntimeConfig for serverSupabaseServiceRole

### DIFF
--- a/src/runtime/server/services/serverSupabaseServiceRole.ts
+++ b/src/runtime/server/services/serverSupabaseServiceRole.ts
@@ -11,7 +11,7 @@ export const serverSupabaseServiceRole: <T = Database>(event: H3Event) => Supaba
     public: {
       supabase: { url },
     },
-  } = useRuntimeConfig()
+  } = useRuntimeConfig(event)
 
   // Make sure service key is set
   if (!serviceKey) {


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
I'm having issues in production because my environment variables are not actually being respected. No problems locally while developing, but when I look at the values that are being pulled for `serviceKey` and `url` in production, they are not receiving the override that I expect from my environment variables. I believe this is the culprit. 

Per [Nuxt's documentation](https://nuxt.com/docs/guide/going-further/runtime-config#server-routes): 
> Giving the event as argument to useRuntimeConfig is optional, but it is recommended to pass it to get the runtime config overwritten by environment variables at runtime for server routes.

I have tested this using [patch-package](https://www.npmjs.com/package/patch-package#benefits-of-patching-over-forking) and confirmed that doing this fixes the behavior.

Is this a bad idea for some reason I'm not aware of?