### PR TITLE
Use private url on service role / allow client-server url separation

### DIFF
--- a/src/runtime/server/services/serverSupabaseServiceRole.ts
+++ b/src/runtime/server/services/serverSupabaseServiceRole.ts
@@ -7,10 +7,7 @@ import type { Database } from '#supabase/database'
 
 export const serverSupabaseServiceRole: <T = Database>(event: H3Event) => SupabaseClient<T> = <T = Database>(event: H3Event) => {
   const {
-    supabase: { serviceKey },
-    public: {
-      supabase: { url },
-    },
+    supabase: { serviceKey, url },
   } = useRuntimeConfig(event)
 
   // Make sure service key is set


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Allow separation of public / private url for service role.
For situations where supabase and client app hosted on same machine SSR side code can go to supabase via localhost.

```
SUPABASE_URL=https://my.api.domain/
SUPABASE_LOCAL_URL=http://localhost:8000/
``` 

config
```
  runtimeConfig: {
    supabase: {
      url: process.env.SUPABASE_LOCAL_URL,
    },
    public: {
      supabase: {
        url: process.env.SUPABASE_URL,
      },
    }
  }
```

maybe public client can also leverage this approach for SSR scenario.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
