### PR TITLE
 Fix `clientOptions` issues and cookie problems

### DIFF
--- a/docs/content/2.get-started.md
+++ b/docs/content/2.get-started.md
@@ -112,11 +112,17 @@ Default:
 - `exclude`: Routes to exclude from the redirect. `['/foo', '/bar/**']` will exclude the `foo` page and all pages in your `bar` folder.
 - `cookieRedirect`: Sets a cookie containing the path an unauthenticated user tried to access. The cookie can then be used on the [`/confirm`](https://supabase.nuxtjs.org/authentication#confirm-page-confirm) page to redirect the user to the page they previously tried to visit.
 
-### `cookieName`
+### `cookiePrefix`
 
-Default: `sb`
+Default: `sb-{your-project-id}-auth-token`
 
-Cookie name used for storing the redirect path when using the `redirect` option, added in front of `-redirect-path` to form the full cookie name e.g. `sb-redirect-path`
+The prefix used for all supabase cookies, and the redirect cookie.
+
+By default, the cookie prefix is the same as the default storage key from the supabase-js client. This includes your project id, and will look something like this: `sb-ttc1xwfwkoleowdqayb19-auth-token`
+
+::callout{icon="i-heroicons-light-bulb"}
+If the `useSsrCookies` option is set to `false`, this option will not affect supabase, and only apply to the `useSupabaseCookieRedirect` cookie.
+::
 
 ### `cookieOptions`
 

--- a/docs/content/2.get-started.md
+++ b/docs/content/2.get-started.md
@@ -74,16 +74,16 @@ Supabase 'service role key', has super admin rights and can bypass your Row Leve
 
 Default: `true`
 
-Controls whether the module uses cookies to share session info between server and client. You *must* enable this option if you need to access session or user info from the server.
+Controls whether the module uses cookies to share session info between server and client. You *must* enable this option if you need to access session or user info from the server. It will use the SSR client from the [@supabase/ssr](https://github.com/supabase/ssr) library.
 
-When disabled, the module will use the default Supabase client which stores session info in local storage. This is useful in certain cases, such as statically generated sites or mobile apps where cookies might not be available.
+When disabled, the module will use the default Supabase client from  the [@supabase/supabase-js](https://github.com/supabase/supabase-js) library which stores session info in local storage. This is useful in certain cases, such as statically generated sites or mobile apps where cookies might not be available.
 
 ::callout{icon="i-heroicons-exclamation-triangle-20-solid"}
 When `useSsrCookies` is `true` the following options cannot be customized with `clientOptions`:
 
 - `flowType`, `autoRefreshToken`, `detectSessionInUrl`, `persistSession`, `storage`
 
-If you need to customize one of the above options, you must set `useSsrCookies` to `false`. Bear in mind that this will disable SSR support.
+If you need to customize one of the above options, you must set `useSsrCookies` to `false`. Bear in mind that this will disable SSR support, you'll need to take care of it yourself if needed. 
 ::
 
 ### `redirect`

--- a/docs/content/2.get-started.md
+++ b/docs/content/2.get-started.md
@@ -102,7 +102,7 @@ Default:
     callback: '/confirm',
     include: undefined,
     exclude: [],
-    cookieRedirect: false,
+    saveRedirectToCookie: false,
   }
 ```
 
@@ -110,7 +110,7 @@ Default:
 - `callback`: This is the path the user will be redirect to after supabase login redirection. Should match configured `redirectTo` option of your [signIn method](https://supabase.com/docs/reference/javascript/auth-signinwithoauth). Should also be configured in your Supabase dashboard under `Authentication -> URL Configuration -> Redirect URLs`.
 - `include`: Routes to include in the redirect. `['/admin(/*)?']` will enable the redirect only for the `admin` page and all sub-pages.
 - `exclude`: Routes to exclude from the redirect. `['/foo', '/bar/**']` will exclude the `foo` page and all pages in your `bar` folder.
-- `cookieRedirect`: Sets a cookie containing the path an unauthenticated user tried to access. The cookie can then be used on the [`/confirm`](https://supabase.nuxtjs.org/authentication#confirm-page-confirm) page to redirect the user to the page they previously tried to visit.
+- `saveRedirectToCookie`: Automatically sets a cookie containing the path an unauthenticated user tried to access. The value can be accessed using the [`useSupabaseCookieRedirect`](/usage/composables/useSupabaseCookieRedirect) composable to redirect the user to the page they previously tried to visit. 
 
 ### `cookiePrefix`
 
@@ -176,6 +176,26 @@ If `useSsrCookies` is enabled, these options will be merged with values from `@s
     },
   }
 ```
+
+### `cookieName`
+
+::callout{color="amber" icon="i-heroicons-exclamation-triangle-20-solid"}
+This option is deprecated, use [`cookiePrefix`](/get-started#cookieprefix) instead.
+::
+
+Default: `sb`
+
+Cookie name used for storing the redirect path when using the `redirectOptions.cookieRedirect` option, added in front of `-redirect-path` to form the full cookie name e.g. `sb-redirect-path`
+
+### `redirectOptions.cookieRedirect`
+
+::callout{color="amber" icon="i-heroicons-exclamation-triangle-20-solid"}
+This option is deprecated, use [`redirectOptions.saveRedirectToCookie`](/get-started#redirectoptions) instead.
+::
+
+Default: `false`
+
+Use the `cookieRedirect` option to store the redirect path in a cookie.
 
 ## Demo
 

--- a/docs/content/2.get-started.md
+++ b/docs/content/2.get-started.md
@@ -70,6 +70,22 @@ Default: `process.env.SUPABASE_SERVICE_KEY`
 
 Supabase 'service role key', has super admin rights and can bypass your Row Level Security.
 
+### `useSsrCookies`
+
+Default: `true`
+
+Controls whether the module uses cookies to share session info between server and client. You *must* enable this option if you need to access session or user info from the server.
+
+When disabled, the module will use the default Supabase client which stores session info in local storage. This is useful in certain cases, such as statically generated sites or mobile apps where cookies might not be available.
+
+::callout{icon="i-heroicons-exclamation-triangle-20-solid"}
+When `useSsrCookies` is `true` the following options cannot be customized with `clientOptions`:
+
+- `flowType`, `autoRefreshToken`, `detectSessionInUrl`, `persistSession`, `storage`
+
+If you need to customize one of the above options, you must set `useSsrCookies` to `false`. Bear in mind that this will disable SSR support.
+::
+
 ### `redirect`
 
 Default: `true`
@@ -140,7 +156,9 @@ Default:
   clientOptions: { }
 ```
 
-Supabase client options [available here](https://supabase.com/docs/reference/javascript/initializing#parameters) merged with default values from `@supabase/ssr`:
+Customize the Supabase client options [available here](https://supabase.com/docs/reference/javascript/initializing#parameters).
+
+If `useSsrCookies` is enabled, these options will be merged with values from `@supabase/ssr`, and some of the [options cannot be customized](/get-started#usessrcookies).
 
 ```ts
   clientOptions: {

--- a/docs/content/3.authentication.md
+++ b/docs/content/3.authentication.md
@@ -54,7 +54,7 @@ Once the authorization flow is triggered using the `auth` wrapper of the [useSup
 
 ## Confirm page - `/confirm`
 
-The confirmation page receives the supabase callback. From there you can check the user value and redirect to the appropriate page.
+The confirmation page receives the supabase callback which contains session information. The supabase client automatically detects and handles this, and once the session is confirmed the user value will automatically be updated. From there you can redirect to the appropriate page.
 
 ::callout{icon="i-heroicons-light-bulb"}
 The redirect URL must be configured in your Supabase dashboard under `Authentication -> URL Configuration -> Redirect URLs`.
@@ -79,30 +79,30 @@ watch(user, () => {
 
 ### Redirect path
 
-You can easily handle redirection to the initial requested route after login.
+You can easily handle redirection to the initial requested route after login using the [`useSupabaseCookieRedirect`](/usage/composables/usesupabasecookieredirect) composable and the [`saveRedirectToCookie`](/get-started#redirectoptions) option.
 
-::callout{icon="i-heroicons-light-bulb"}
-You must enable the `cookieRedirect` option of the [redirectOptions](/get-started#redirectoptions) to allow cookie storage and take benefit of this feature.
-::
+By setting the `saveRedirectToCookie` option to `true`, the module will automatically save the current path to a cookie when the user is redirected to the login page. When the user logs in, you can then retrieve the saved path from the cookie and redirect the user to it on the [`/confirm`](/authentication#confirm-page-confirm) page:
 
 ```vue [pages/confirm.vue]
 <script setup lang="ts">
 const user = useSupabaseUser()
-
-// Get redirect path from cookies
-const cookieName = useRuntimeConfig().public.supabase.cookieName
-const redirectPath = useCookie(`${cookieName}-redirect-path`).value
+const redirectInfo = useSupabaseCookieRedirect()
 
 watch(user, () => {
   if (user.value) {
-      // Clear cookie
-      useCookie(`${cookieName}-redirect-path`).value = null
-      // Redirect to path
-      return navigateTo(redirectPath || '/'); 
+    // Get redirect path, and clear it from the cookie
+    const path = redirectInfo.pluck()
+    // Redirect to the saved path, or fallback to home
+    return navigateTo(path || '/') 
   }
 }, { immediate: true })
 </script>
+
 <template>
   <div>Waiting for login...</div>
 </template>
 ```
+
+::callout{icon="i-heroicons-light-bulb"}
+If you want to manually set the redirect path, you can do so by disabling [`saveRedirectToCookie`](/get-started#redirectoptions), and then set the value using the  [`useSupabaseCookieRedirect`](/usage/composables/usesupabasecookieredirect) composable directly.
+::

--- a/docs/content/4.usage/composables/useSupabaseCookieRedirect.md
+++ b/docs/content/4.usage/composables/useSupabaseCookieRedirect.md
@@ -1,0 +1,54 @@
+---
+title: useSupabaseCookieRedirect
+description: Handle redirecting users to the page they previously tried to visit after login
+---
+
+The `useSupabaseCookieRedirect` composable provides a simple way to handle storing and retrieving a redirect path with a cookie.
+
+## Usage
+
+This composable can be [manually used](#manual-usage) to save and retrieve a redirect path. However, the redirect path can automatically be set via the `saveRedirectToCookie` option in the [redirectOptions](/get-started#redirectoptions).
+
+The redirect path is not automatically used. Instead you must implement the logic to redirect the user to the saved path, for example on the [`/confirm`](/authentication#confirm-page-confirm) page.
+
+```vue
+<script setup>
+const user = useSupabaseUser()
+const redirectInfo = useSupabaseCookieRedirect()
+
+watch(user, () => {
+  if (user.value) {
+    // Get the saved path and clear it from the cookie
+    const path = redirectInfo.pluck()
+    // Redirect to the saved path, or fallback to home
+    return navigateTo(path || '/')
+  }
+}, { immediate: true })
+</script>
+```
+
+## Return Values
+
+The composable returns an object with the following properties:
+
+- `path`: A reactive cookie reference containing the redirect path. Can be both read and written to.
+- `pluck()`: A convenience method that returns the current redirect path and clears it from the cookie.
+
+## Manual Usage
+
+You can also manually set and read the redirect path:
+
+```ts
+const redirectInfo = useSupabaseCookieRedirect()
+
+// Save a specific path
+redirectInfo.path.value = '/dashboard'
+
+// Read the current path without clearing it
+const currentPath = redirectInfo.path.value
+
+// Get the path and clear it
+const path = redirectInfo.pluck()
+``` 
+
+The cookie is saved with the name `{cookiePrefix}-redirect-path` where `cookiePrefix` is defined in the [runtime config](/get-started#runtime-config).

--- a/src/module.ts
+++ b/src/module.ts
@@ -60,6 +60,7 @@ export interface ModuleOptions {
    * Cookie name used for storing the redirect path when using the `redirect` option, added in front of `-redirect-path` to form the full cookie name e.g. `sb-redirect-path`
    * @default 'sb'
    * @type string
+   * @deprecated Use `cookiePrefix` instead.
    */
   cookieName?: string
 
@@ -126,6 +127,7 @@ export default defineNuxtModule<ModuleOptions>({
       callback: '/confirm',
       exclude: [],
       cookieRedirect: false,
+      saveRedirectToCookie: false,
     },
     cookieName: 'sb',
     cookiePrefix: undefined,
@@ -177,6 +179,14 @@ export default defineNuxtModule<ModuleOptions>({
     // Warn if the key isn't set.
     if (!nuxt.options.runtimeConfig.public.supabase.key) {
       logger.warn('Missing supabase anon key, set it either in `nuxt.config.js` or via env variable')
+    }
+
+    // Warn for deprecated features.
+    if (nuxt.options.runtimeConfig.public.supabase.redirectOptions.cookieRedirect) {
+      logger.warn('The `cookieRedirect` option is deprecated, use `saveRedirectToCookie` instead.')
+    }
+    if (nuxt.options.runtimeConfig.public.supabase.cookieName != 'sb') {
+      logger.warn('The `cookieName` option is deprecated, use `cookiePrefix` instead.')
     }
 
     // ensure callback URL is not using SSR

--- a/src/module.ts
+++ b/src/module.ts
@@ -64,6 +64,16 @@ export interface ModuleOptions {
   cookieName?: string
 
   /**
+   * If true, the supabase client will use cookies to store the session, allowing the session to be used from the server in ssr mode.
+   * Some `clientOptions` are not configurable when this is enabled. See the docs for more details.
+   *
+   * If false, the server will not be able to access the session.
+   * @default true
+   * @type boolean
+   */
+  useSsrCookies?: boolean
+
+  /**
    * Cookie options
    * @default {
       maxAge: 60 * 60 * 8,
@@ -111,6 +121,7 @@ export default defineNuxtModule<ModuleOptions>({
       cookieRedirect: false,
     },
     cookieName: 'sb',
+    useSsrCookies: true,
     cookieOptions: {
       maxAge: 60 * 60 * 8,
       sameSite: 'lax',

--- a/src/runtime/composables/useSupabaseCookieRedirect.ts
+++ b/src/runtime/composables/useSupabaseCookieRedirect.ts
@@ -1,0 +1,40 @@
+import type { CookieRef } from 'nuxt/app'
+import { useRuntimeConfig, useCookie, useRoute } from '#imports'
+
+export interface UseSupabaseCookieRedirectReturn {
+  /**
+   * The reactive value of the redirect path cookie.
+   * Can be both read and written to.
+   */
+  path: CookieRef<string | null>
+  /**
+   * Get the current redirect path cookie value, then clear it
+   */
+  pluck: () => string | null
+}
+
+export const useSupabaseCookieRedirect = (): UseSupabaseCookieRedirectReturn => {
+  const config = useRuntimeConfig().public.supabase
+
+  // Use cookiePrefix if saveRedirectToCookie is true, otherwise fallback to the deprecated cookieName
+  const prefix = config.redirectOptions.saveRedirectToCookie
+    ? config.cookiePrefix
+    : config.cookieName
+
+  const cookie: CookieRef<string | null> = useCookie(
+    `${prefix}-redirect-path`,
+    {
+      ...config.cookieOptions,
+      readonly: false,
+    },
+  )
+
+  return {
+    path: cookie,
+    pluck: () => {
+      const value = cookie.value
+      cookie.value = null
+      return value
+    },
+  }
+}

--- a/src/runtime/composables/useSupabaseCookieRedirect.ts
+++ b/src/runtime/composables/useSupabaseCookieRedirect.ts
@@ -1,5 +1,5 @@
 import type { CookieRef } from 'nuxt/app'
-import { useRuntimeConfig, useCookie, useRoute } from '#imports'
+import { useRuntimeConfig, useCookie } from '#imports'
 
 export interface UseSupabaseCookieRedirectReturn {
   /**

--- a/src/runtime/plugins/supabase.client.ts
+++ b/src/runtime/plugins/supabase.client.ts
@@ -17,6 +17,7 @@ export default defineNuxtPlugin({
         ...clientOptions,
         cookieOptions: {
           ...cookieOptions,
+          name: cookiePrefix,
         },
         isSingleton: true,
         global: {

--- a/src/runtime/plugins/supabase.client.ts
+++ b/src/runtime/plugins/supabase.client.ts
@@ -1,5 +1,5 @@
 import { createBrowserClient } from '@supabase/ssr'
-import type { Session, SupabaseClient } from '@supabase/supabase-js'
+import { type Session, type SupabaseClient, createClient } from '@supabase/supabase-js'
 import { fetchWithRetry } from '../utils/fetch-retry'
 import type { Plugin } from '#app'
 import { defineNuxtPlugin, useRuntimeConfig, useSupabaseSession, useSupabaseUser } from '#imports'
@@ -8,17 +8,32 @@ export default defineNuxtPlugin({
   name: 'supabase',
   enforce: 'pre',
   async setup({ provide }) {
-    const { url, key, cookieOptions, clientOptions } = useRuntimeConfig().public.supabase
+    const { url, key, cookieOptions, cookiePrefix, useSsrCookies, clientOptions } = useRuntimeConfig().public.supabase
 
-    const client = createBrowserClient(url, key, {
-      ...clientOptions,
-      cookieOptions,
-      isSingleton: true,
-      global: {
-        fetch: fetchWithRetry,
-        ...clientOptions.global,
-      },
-    })
+    let client
+
+    if (useSsrCookies) {
+      client = createBrowserClient(url, key, {
+        ...clientOptions,
+        cookieOptions: {
+          ...cookieOptions,
+        },
+        isSingleton: true,
+        global: {
+          fetch: fetchWithRetry,
+          ...clientOptions.global,
+        },
+      })
+    }
+    else {
+      client = createClient(url, key, {
+        ...clientOptions,
+        global: {
+          fetch: fetchWithRetry,
+          ...clientOptions.global,
+        },
+      })
+    }
 
     provide('supabase', { client })
 

--- a/src/runtime/plugins/supabase.server.ts
+++ b/src/runtime/plugins/supabase.server.ts
@@ -35,16 +35,18 @@ export default defineNuxtPlugin({
 
     provide('supabase', { client })
 
-    // Initialize user and session states
-    const [
-      session,
-      user,
-    ] = await Promise.all([
-      serverSupabaseSession(event).catch(() => null),
-      serverSupabaseUser(event).catch(() => null),
-    ])
+    // Initialize user and session states if available.
+    if (useSsrCookies) {
+      const [
+        session,
+        user,
+      ] = await Promise.all([
+        serverSupabaseSession(event).catch(() => null),
+        serverSupabaseUser(event).catch(() => null),
+      ])
 
-    useSupabaseSession().value = session
-    useSupabaseUser().value = user
+      useSupabaseSession().value = session
+      useSupabaseUser().value = user
+    }
   },
 }) as Plugin<{ client: SupabaseClient }>

--- a/src/runtime/plugins/supabase.server.ts
+++ b/src/runtime/plugins/supabase.server.ts
@@ -10,7 +10,7 @@ export default defineNuxtPlugin({
   name: 'supabase',
   enforce: 'pre',
   async setup({ provide }) {
-    const { url, key, cookieOptions, clientOptions } = useRuntimeConfig().public.supabase
+    const { url, key, cookiePrefix, useSsrCookies, cookieOptions, clientOptions } = useRuntimeConfig().public.supabase
 
     const event = useRequestEvent()!
 
@@ -26,7 +26,10 @@ export default defineNuxtPlugin({
           }[],
         ) => cookies.forEach(({ name, value, options }) => setCookie(event, name, value, options)),
       },
-      cookieOptions,
+      cookieOptions: {
+        ...cookieOptions,
+        name: cookiePrefix,
+      },
       global: {
         fetch: fetchWithRetry,
         ...clientOptions.global,

--- a/src/runtime/server/services/serverSupabaseClient.ts
+++ b/src/runtime/server/services/serverSupabaseClient.ts
@@ -10,14 +10,7 @@ export const serverSupabaseClient: <T = Database>(event: H3Event) => Promise<Sup
   // No need to recreate client if exists in request context
   if (!event.context._supabaseClient) {
     // get settings from runtime config
-    const {
-      supabase: {
-        url,
-        key,
-        cookieOptions,
-        clientOptions: { auth = {}, global = {} },
-      },
-    } = useRuntimeConfig().public
+    const { url, key, cookiePrefix, cookieOptions, clientOptions: { auth = {}, global = {} } } = useRuntimeConfig().public.supabase
 
     event.context._supabaseClient = createServerClient(url, key, {
       auth,
@@ -31,7 +24,10 @@ export const serverSupabaseClient: <T = Database>(event: H3Event) => Promise<Sup
           }[],
         ) => cookies.forEach(({ name, value, options }) => setCookie(event, name, value, options)),
       },
-      cookieOptions,
+      cookieOptions: {
+        ...cookieOptions,
+        name: cookiePrefix,
+      },
       global: {
         fetch: fetchWithRetry,
         ...global,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,5 +23,14 @@ export interface RedirectOptions {
   callback: string
   include?: string[]
   exclude?: string[]
+  /**
+   * @deprecated Use `saveRedirectToCookie` instead.
+   */
   cookieRedirect?: boolean
+
+  /**
+   * If true, the when automatically redirected the redirect path will be saved to a cookie, allowing retrieval later with the `useSupabaseRedirect` composable.
+   * @default false
+   */
+  saveRedirectToCookie?: boolean
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ declare module '@nuxt/schema' {
       redirect: boolean
       redirectOptions: RedirectOptions
       cookieName: string
+      cookiePrefix: string
       useSsrCookies: boolean
       cookieOptions: CookieOptions
       types: string | false

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,7 +29,7 @@ export interface RedirectOptions {
   cookieRedirect?: boolean
 
   /**
-   * If true, the when automatically redirected the redirect path will be saved to a cookie, allowing retrieval later with the `useSupabaseRedirect` composable.
+   * If true, when automatically redirected the redirect path will be saved to a cookie, allowing retrieval later with the `useSupabaseRedirect` composable.
    * @default false
    */
   saveRedirectToCookie?: boolean

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ declare module '@nuxt/schema' {
       redirect: boolean
       redirectOptions: RedirectOptions
       cookieName: string
+      useSsrCookies: boolean
       cookieOptions: CookieOptions
       types: string | false
       clientOptions: SupabaseClientOptions<string>


### PR DESCRIPTION
The following issues are all more or less related to the same set of problems. This pull request aims to add options that solve all of these problems, and make the module more flexible and consistent!


### `createBrowserClient` issues

Currently, the`createBrowserClient` [overrides multiple client options](https://github.com/supabase/ssr/blob/ef429dfbd1dc9f446bdef009717dfc6d8a2e3c85/src/createBrowserClient.ts#L140), causing multiple issues:

- You can't set `detectSessionInUrl` to false in the client options (this is caused from the override). In my static site, I need to handle the session manually.
- [Issue: Setting persistSession: false still persists auth session](https://github.com/nuxt-modules/supabase/issues/390) (this is caused from the override)
- [Issue: The module doesn't recognize supabase.clientOptions.auth.flowType key](https://github.com/nuxt-modules/supabase/issues/449) (this is caused from the override)
- [Issue: Detecting session in URL is not working when sending "Password recovery" email manually from Supabase dashboard](https://github.com/nuxt-modules/supabase/issues/397#issuecomment-2521569863) (supabase ssr prevents using the implicit flow)
- [Issue: Static Hosting: Client side only rendering gives error when signing in with email](https://github.com/nuxt-modules/supabase/issues/138) (this would be solved if you use `createClient` instead of `createBrowserClient`.)
- [Issue: Non-cookie token storage](https://github.com/nuxt-modules/supabase/issues/186) (there's currently not a way to disable use of cookies)
  
  In certain environments you might not be able to set a cookie, so the local storage behavior would be preferred. 
  Although a hack, the following code also doesn't work because the client options are overwritten:
  [Override storage to use local storage](https://github.com/nuxt-modules/supabase/issues/186#issuecomment-2608926000)
  
It seems based on these comments that supabase ssr wants to keep these methods overwritten:

- [Update authentication options in createServerClient](https://github.com/supabase/ssr/pull/60#issuecomment-237019153)
- [Can't bypass the auth options](https://github.com/supabase/ssr/issues/59#issuecomment-2330348853)

### Cookie issues

Along with some of the issues above which related to cookies, there are multiple inconsistent behaviors of the cookie options:

- Currently, you can set `cookieName` in the config, however this only applies to the redirect cookie. 
- In order to access the redirect cookie, you need to manually get the cookie name from the module, and append `-redirect-path` to it.
- `cookieOptions` on the other hand is used for the redirect cookie, *and* is passed to the supabase ssr clients.
- The docs do not mention that the `cookieOptions` are used for the redirect cookie.
- `cookieName` is misleading, as it's not the name of the cookie, but the prefix.
- You currently can't change the cookie prefix for supabase itself.


## Changes made

- Added a `useSsrCookies` option to the config which if enabled, uses the `createBrowserClient` method to construct the client. By default this is true, so the behavior will not change when updating the module.

  If disabled, the module will use the `createClient` method directly. This allows you to completely customize the client options, and store the session info in local storage. See the docs changes for a more detailed explanation.

  This indirectly solves most issues related to the inability to customize the client options, or disable cookie storage.

- Renamed `cookieName` to `cookiePrefix` to more accurately reflect what it does. The prefix also now applies to the supabase cookies, allowing for total customization of all cookies when using `serverSupabaseClient` and `useSupabaseClient`.

- Renamed `cookieRedirect` to `saveRedirectToCookie` to better reflect what it does.

- Added a `useSupabaseCookieRedirect` composable that handles getting and setting the cookie redirect value. This abstracts out the cookie retrieval so you don't have to hard code the name. It also allows for manually setting the redirect path if needed. See the docs for more details.

  <details>
    <summary>Example of using the composable</summary>
    before:

    ```ts
    const user = useSupabaseUser()

    // Get redirect path from cookies
    const cookieName = useRuntimeConfig().public.supabase.cookieName
    const redirectPath = useCookie(`${cookieName}-redirect-path`).value

    watch(user, () => {
      if (user.value) {
          // Clear cookie
          useCookie(`${cookieName}-redirect-path`).value = null
          // Redirect to path
          return navigateTo(redirectPath || '/'); 
      }
    }, { immediate: true })
    ```   

    after:

    ```ts
    const user = useSupabaseUser()
    const redirectInfo = useSupabaseCookieRedirect()

    watch(user, () => {
      if (user.value) {
        // Redirect to the previously saved path, clearing it in the process
        const path = redirectInfo.pluck()
        return navigateTo(path || '/'); 
      }
    }, { immediate: true })
    ```
  </details>

- Updated the docs to thoroughly explain in more detail how to use these options and the caveats to the issues described. Hopefully this can solve, or at least explain a lot of peoples issues!

#### Does this break anything?

It shouldn't. Everything is opt in, and both `cookieName` and `cookiePrefix` have been deprecated, so existing setups will not be affected and will behave as before.

#### Other solutions considered

<details>
  <summary>Show more</summary>
  This change doesn't fix the problem where you can't set certain options like `detectSessionInUrl` with `useSsrCookies` enabled. It does however, let you disable cookies letting you fully customize it.

  The only way to fix it directly is to remove the `createBrowserClient` method entirely and implement a custom version of it, however the source code for it is [very large](https://github.com/supabase/ssr/blob/ef429dfbd1dc9f446bdef009717dfc6d8a2e3c85/src/cookies.ts#L173), and making a change to it could break things if the `createServerClient` method is changed.

  Since `@supabase/ssr` is the official package for ssr, it makes sense to not touch it. It's also technically still in beta, so it's possible that this specific issue of config overrides could be fixed in the future.
</details>

---

I'd appreciate any feedback on the changes! I would love to get this merged as I love this module!

Thanks!
