### PR TITLE
Pass H3Event into useRuntimeConfig for serverSupabaseClient

### DIFF
--- a/src/runtime/server/services/serverSupabaseClient.ts
+++ b/src/runtime/server/services/serverSupabaseClient.ts
@@ -10,7 +10,7 @@ export const serverSupabaseClient: <T = Database>(event: H3Event) => Promise<Sup
   // No need to recreate client if exists in request context
   if (!event.context._supabaseClient) {
     // get settings from runtime config
-    const { url, key, cookiePrefix, cookieOptions, clientOptions: { auth = {}, global = {} } } = useRuntimeConfig().public.supabase
+    const { url, key, cookiePrefix, cookieOptions, clientOptions: { auth = {}, global = {} } } = useRuntimeConfig(event).public.supabase
 
     event.context._supabaseClient = createServerClient(url, key, {
       auth,


### PR DESCRIPTION

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

Similar to https://github.com/nuxt-modules/supabase/pull/450, I faced issues when deploying this module to a Cloudflare worker. It would not find the supabase runtime config on the server-side.

I tried to reproduce it, and passing the event makes the runtime config work correctly

```ts
  return {
    a: useRuntimeConfig().public.supabase, // <- missing keys
    b: useRuntimeConfig(event).public.supabase, // <- works
  };
```

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
