### PR TITLE
fix: use "unjs/pathe" to make the exported type use relative path

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from 'node:url'
 import fs from 'node:fs'
 import { defu } from 'defu'
+import { relative } from 'pathe'
 import { defineNuxtModule, addPlugin, createResolver, addTemplate, extendViteConfig, useLogger, addImportsDir } from '@nuxt/kit'
 import type { CookieOptions } from 'nuxt/app'
 import type { SupabaseClientOptions } from '@supabase/supabase-js'
@@ -247,11 +248,11 @@ export default defineNuxtModule<ModuleOptions>({
         if (options.types) {
           // resolvePath is used to minify user input error.
           const path = await resolvePath(options.types)
-          const basePath = await resolvePath('~~') // ~~ should be the base path in a nuxt project.
+          const typesPath = await resolvePath('~~/.nuxt/types/') // this is the default path for nuxt types
 
           if (fs.existsSync(path)) {
-            // we are replacing the basePath with ../.. to move back to the root (~~) directory.
-            return `export * from '${path.replace(basePath, '../..')}'`
+            // Make the path relative to the "types" directory.
+            return `export * from '${relative(typesPath, path)}'`
           }
         }
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
The generated types file `.nuxt/types/supabase-database.d.ts` contains broken paths examples I tested

|path|nuxt.config.ts|supabase-database.d.ts|
|:--|:--|:--|
|`/app/types/database.types.ts`|`~/types/database.types.ts`|`../..app/types/database.types.ts`
|`/types/database.types.ts`|`~~/types/database.types.ts`|`../..types/database.types.ts`

The problem is the missing `/` before the directory name.

So I instead of using a string replacement, it now uses `unjs/pathe` relative to resolve the path correctly 

Resolves: #515

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

How can I add tests for this kind of change? I tested these changes manually in my Nuxt 4 Project.

Manual testing:
1. Run `npm run dev:prepare`
2. Take a look at playgrounds `.nuxt/types/supabase-database.d.ts` file. Wrong path is used.
```ts
export * from '../..types/database.types.ts'
```
3. Use this PR and do the same. Now the path should be correct like this
```ts
export * from '../../types/database.types.ts'
```
