### PR TITLE
fix(#518): guard cookie writes when response headers already sent

### DIFF
--- a/src/runtime/plugins/supabase.server.ts
+++ b/src/runtime/plugins/supabase.server.ts
@@ -1,7 +1,8 @@
 import { createServerClient, parseCookieHeader } from '@supabase/ssr'
-import { getHeader, setCookie } from 'h3'
+import { getHeader } from 'h3'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { fetchWithRetry } from '../utils/fetch-retry'
+import { setCookies } from '../utils/cookies'
 import { serverSupabaseUser, serverSupabaseSession } from '../server/services'
 import { useSupabaseSession } from '../composables/useSupabaseSession'
 import { useSupabaseUser } from '../composables/useSupabaseUser'
@@ -21,26 +22,7 @@ export default defineNuxtPlugin({
       ...clientOptions,
       cookies: {
         getAll: () => parseCookieHeader(getHeader(event, 'Cookie') ?? ''),
-        setAll: (
-          cookies: {
-            name: string
-            value: string
-            options: CookieOptions
-          }[],
-        ) => {
-          const response = event.node.res
-          const headersWritable = () => !response.headersSent && !response.writableEnded
-
-          if (!headersWritable()) {
-            return
-          }
-          for (const { name, value, options } of cookies) {
-            if (!headersWritable()) {
-              break
-            }
-            setCookie(event, name, value, options)
-          }
-        },
+        setAll: (cookies: { name: string, value: string, options: CookieOptions }[]) => setCookies(event, cookies),
       },
       cookieOptions: {
         ...cookieOptions,

--- a/src/runtime/plugins/supabase.server.ts
+++ b/src/runtime/plugins/supabase.server.ts
@@ -27,7 +27,20 @@ export default defineNuxtPlugin({
             value: string
             options: CookieOptions
           }[],
-        ) => cookies.forEach(({ name, value, options }) => setCookie(event, name, value, options)),
+        ) => {
+          const response = event.node.res
+          const headersWritable = () => !response.headersSent && !response.writableEnded
+
+          if (!headersWritable()) {
+            return
+          }
+          for (const { name, value, options } of cookies) {
+            if (!headersWritable()) {
+              break
+            }
+            setCookie(event, name, value, options)
+          }
+        },
       },
       cookieOptions: {
         ...cookieOptions,

--- a/src/runtime/server/services/serverSupabaseClient.ts
+++ b/src/runtime/server/services/serverSupabaseClient.ts
@@ -23,7 +23,20 @@ export const serverSupabaseClient: <T = Database>(event: H3Event) => Promise<Sup
             value: string
             options: CookieOptions
           }[],
-        ) => cookies.forEach(({ name, value, options }) => setCookie(event, name, value, options)),
+        ) => {
+          const response = event.node.res
+          const headersWritable = () => !response.headersSent && !response.writableEnded
+
+          if (!headersWritable()) {
+            return
+          }
+          for (const { name, value, options } of cookies) {
+            if (!headersWritable()) {
+              break
+            }
+            setCookie(event, name, value, options)
+          }
+        },
       },
       cookieOptions: {
         ...cookieOptions,

--- a/src/runtime/server/services/serverSupabaseClient.ts
+++ b/src/runtime/server/services/serverSupabaseClient.ts
@@ -1,7 +1,9 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { createServerClient, parseCookieHeader, type CookieOptions } from '@supabase/ssr'
-import { getHeader, setCookie, type H3Event } from 'h3'
+import { createServerClient, parseCookieHeader } from '@supabase/ssr'
+import { getHeader, type H3Event } from 'h3'
 import { fetchWithRetry } from '../../utils/fetch-retry'
+import { setCookies } from '../../utils/cookies'
+import type { CookieOptions } from '#app'
 import { useRuntimeConfig } from '#imports'
 // @ts-expect-error - `#supabase/database` is a runtime alias
 import type { Database } from '#supabase/database'
@@ -17,26 +19,7 @@ export const serverSupabaseClient: <T = Database>(event: H3Event) => Promise<Sup
       auth,
       cookies: {
         getAll: () => parseCookieHeader(getHeader(event, 'Cookie') ?? ''),
-        setAll: (
-          cookies: {
-            name: string
-            value: string
-            options: CookieOptions
-          }[],
-        ) => {
-          const response = event.node.res
-          const headersWritable = () => !response.headersSent && !response.writableEnded
-
-          if (!headersWritable()) {
-            return
-          }
-          for (const { name, value, options } of cookies) {
-            if (!headersWritable()) {
-              break
-            }
-            setCookie(event, name, value, options)
-          }
-        },
+        setAll: (cookies: { name: string, value: string, options: CookieOptions }[]) => setCookies(event, cookies),
       },
       cookieOptions: {
         ...cookieOptions,

--- a/src/runtime/utils/cookies.ts
+++ b/src/runtime/utils/cookies.ts
@@ -1,0 +1,25 @@
+import { setCookie, type H3Event } from 'h3'
+import type { CookieOptions } from '#app'
+
+export function setCookies(
+  event: H3Event,
+  cookies: {
+    name: string
+    value: string
+    options: CookieOptions
+  }[],
+) {
+  const response = event.node.res
+  const headersWritable = () => !response.headersSent && !response.writableEnded
+
+  if (!headersWritable()) {
+    return
+  }
+
+  for (const { name, value, options } of cookies) {
+    if (!headersWritable()) {
+      break
+    }
+    setCookie(event, name, value, options)
+  }
+}


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
This PR implements a defensive guard for SSR cookie writes.  
Previously, `setAll` unconditionally attempted to call `setCookie` even when the H3/Node response headers had already been sent. This caused runtime errors and unhandledRejection spam during token refresh in dev after idle:

```
ERROR Cannot remove headers after they are sent to the client
    at ServerResponse.removeHeader (node:_http_outgoing:848:11)
    at setCookie (h3/dist/index.mjs:615:18)
    at node_modules/@nuxtjs/supabase/dist/runtime/plugins/supabase.server.js:31:111
    at Array.forEach (<anonymous>)
    at setAll (.../node_modules/@nuxtjs/supabase/dist/runtime/plugins/supabase.server.js:31:38)
    at applyServerStorage (.../@supabase/ssr/dist/module/cookies.js:274:9)
    at async Object.callback (.../@supabase/ssr/dist/module/createServerClient.js:51:13)
    at async .../@supabase/auth-js/dist/module/GoTrueClient.js:1604:11
    at async Promise.all (index 1)
```

The fix introduces a `headersWritable` check in both `runtime/plugins/supabase.server.js` and `runtime/server/services/serverSupabaseClient.js`.  
If headers are already sent or the response has ended, cookie writes are skipped.  
This prevents crashes and log spam without altering normal behavior when headers are writable.

Resolves: #518


## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes